### PR TITLE
Add flatpak manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ Makefile.bak
 .cache
 .vs
 .vscode
+.flatpak-builder
 
 engines/phalanx-scid/phalanx-scid
 engines/togaII1.2.1a/src/.depend

--- a/com.github.benini.scid.yml
+++ b/com.github.benini.scid.yml
@@ -8,8 +8,7 @@ command: scid
 finish-args:
   - --filesystem=home        # for accessing files in the user's home folder
   - --share=network          # access the network
-  - --socket=wayland         # show windows with wayland
-  - --socket=fallback-x11    # show windows using X11, if wayland is not available
+  - --socket=x11             # show windows with x11
   - --share=ipc              # share IPC namespace with the host (necessary for X11)
   - --device=dri             # OpenGL rendering
   - --socket=pulseaudio      # play sound with PulseAudio

--- a/com.github.benini.scid.yml
+++ b/com.github.benini.scid.yml
@@ -1,0 +1,114 @@
+app-id: com.github.benini.scid
+branch: stable
+runtime: org.freedesktop.Platform
+runtime-version: '22.08'
+sdk: org.freedesktop.Sdk
+command: scid
+
+finish-args:
+  - --filesystem=home        # for accessing files in the user's home folder
+  - --share=network          # access the network
+  - --socket=wayland         # show windows with wayland
+  - --socket=fallback-x11    # show windows using X11, if wayland is not available
+  - --share=ipc              # share IPC namespace with the host (necessary for X11)
+  - --device=dri             # OpenGL rendering
+  - --socket=pulseaudio      # play sound with PulseAudio
+
+modules:
+- name: stockfish # Stockfish engine, put into /app/bin/Engines/stockfish/
+  buildsystem: simple
+  build-commands:
+  - cp nn-ad9b42354671.nnue ./src
+  - cd src; make -j build
+  - mkdir -p /app/bin/Engines/stockfish
+  - cp ./src/stockfish /app/bin/Engines/stockfish/
+  - cp ./nn-ad9b42354671.nnue /app/bin/Engines/stockfish/
+  sources:
+  - type: archive
+    url: https://github.com/official-stockfish/Stockfish/archive/refs/tags/sf_15.1.zip
+    sha256: 5174e4247f4c107648c9f7c906d5e9733abc61c6dae047be570cee2b930f0339
+  - type: file
+    url: https://tests.stockfishchess.org/api/nn/nn-ad9b42354671.nnue
+    sha256: ad9b423546714137916bd38978af6fd68d7b8951bef25ff76bf43da72d6cb786
+
+- name: eigen # library for linear algebra, used for lc0
+  buildsystem: cmake-ninja
+  builddir: true
+  sources:
+  - type: archive
+    url: https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz
+    sha256: 8586084f71f9bde545ee7fa6d00288b264a2b7ac3607b974e54d13e7162c1c72
+
+- name: openblas # Basic Linear Algebra Subprograms library, used for lc0
+  no-autogen: true
+  make-args:
+  - DYNAMIC_ARCH=1
+  - FC=gfortran
+  - NO_LAPACKE=1
+  - USE_OPENMP=0
+  make-install-args:
+  - PREFIX=/app
+  post-install:
+  - rm /app/lib/*.a
+  sources:
+  - type: archive
+    url: https://github.com/xianyi/OpenBLAS/archive/refs/tags/v0.3.21.tar.gz
+    sha256: f36ba3d7a60e7c8bcc54cd9aaa9b1223dd42eaf02c811791c37e8ca707c241ca
+
+- name: lc0 # Lc0 engine, put into /app/bin/Engines/lc0
+  buildsystem: meson
+  config-opts:
+  - "-Dopenblas=true"
+  - "-Dopenblas_libdirs=/app/lib"
+  - "-Dgtest=false"
+  - "-Db_lto=true"
+  - "-Dopencl=false"
+  post-install:
+  - mkdir -p /app/bin/Engines/lc0
+  - mv /app/bin/lc0 /app/bin/Engines/lc0/
+  sources:
+  - type: archive
+    url: https://github.com/LeelaChessZero/lc0/archive/refs/tags/v0.29.0.zip
+    sha256: 91b8c76db7009ae4592bd0e87d2f6fda01fc33c819264d107fd6fc16330cc868
+  - type: archive
+    dest: "./libs/lczero-common/"
+    url: https://github.com/LeelaChessZero/lczero-common/archive/refs/heads/master.zip
+    sha256: 441eac56bf31aa966fd9baeecf2a71a2018475bd7c55310f61462fc7c8f2954c
+
+- name: nn # neural network T79, added to Lc0 (see https://lczero.org/play/networks/bestnets/)
+  buildsystem: simple
+  build-commands:
+  - mkdir -p /app/bin/Engines/lc0
+  - mv nn /app/bin/Engines/lc0/
+  sources:
+  - type: file
+    dest-filename: nn
+    url: https://training.lczero.org/get_network?sha=195b450999e874d07aea2c09fd0db5eff9d4441ec1ad5a60a140fe8ea94c4f3a
+    sha256: 5cf80e9e5091134241235400366c6c46c8b1613b07b98243f4e4dcc691bf47ae
+
+- name: tcl # latest stable tcl, required for scid
+  sources:
+    - type: archive
+      url: https://prdownloads.sourceforge.net/tcl/tcl8.6.13-src.tar.gz
+      sha256: 43a1fae7412f61ff11de2cfd05d28cfc3a73762f354a417c62370a54e2caf066
+  subdir: "unix"
+  post-install:
+    - chmod 755 /app/lib/libtcl*.so
+
+- name: tk # latest stable tk, required for scid
+  sources:
+    - type: archive
+      url: https://prdownloads.sourceforge.net/tcl/tk8.6.13-src.tar.gz
+      sha256: 2e65fa069a23365440a3c56c556b8673b5e32a283800d8d9b257e3f584ce0675
+  subdir: "unix"
+  post-install:
+    - chmod 755 /app/lib/libtk*.so
+
+- name: scid # main app
+  buildsystem: cmake-ninja
+  builddir: true
+  sources:
+    - type: git
+      url: https://github.com/benini/scid.git
+      tag: v4.8.0
+      commit: 43740990c3ee47d662d57d11bedac6e667a06fd8

--- a/com.github.benini.scid.yml
+++ b/com.github.benini.scid.yml
@@ -15,14 +15,14 @@ finish-args:
   - --socket=pulseaudio      # play sound with PulseAudio
 
 modules:
-- name: stockfish # Stockfish engine, put into /app/bin/Engines/stockfish/
+- name: stockfish # Stockfish engine, put into /app/engines/stockfish/
   buildsystem: simple
   build-commands:
   - cp nn-ad9b42354671.nnue ./src
   - cd src; make -j build
-  - mkdir -p /app/bin/Engines/stockfish
-  - cp ./src/stockfish /app/bin/Engines/stockfish/
-  - cp ./nn-ad9b42354671.nnue /app/bin/Engines/stockfish/
+  - mkdir -p /app/engines/stockfish
+  - cp ./src/stockfish /app/engines/stockfish/
+  - cp ./nn-ad9b42354671.nnue /app/engines/stockfish/
   sources:
   - type: archive
     url: https://github.com/official-stockfish/Stockfish/archive/refs/tags/sf_15.1.zip
@@ -55,7 +55,7 @@ modules:
     url: https://github.com/xianyi/OpenBLAS/archive/refs/tags/v0.3.21.tar.gz
     sha256: f36ba3d7a60e7c8bcc54cd9aaa9b1223dd42eaf02c811791c37e8ca707c241ca
 
-- name: lc0 # Lc0 engine, put into /app/bin/Engines/lc0
+- name: lc0 # Lc0 engine, put into /app/engines/lc0
   buildsystem: meson
   config-opts:
   - "-Dopenblas=true"
@@ -64,8 +64,8 @@ modules:
   - "-Db_lto=true"
   - "-Dopencl=false"
   post-install:
-  - mkdir -p /app/bin/Engines/lc0
-  - mv /app/bin/lc0 /app/bin/Engines/lc0/
+  - mkdir -p /app/engines/lc0
+  - mv /app/bin/lc0 /app/engines/lc0/
   sources:
   - type: archive
     url: https://github.com/LeelaChessZero/lc0/archive/refs/tags/v0.29.0.zip
@@ -78,13 +78,13 @@ modules:
 - name: nn # neural network T79, added to Lc0 (see https://lczero.org/play/networks/bestnets/)
   buildsystem: simple
   build-commands:
-  - mkdir -p /app/bin/Engines/lc0
-  - mv nn /app/bin/Engines/lc0/
+  - mkdir -p /app/engines/lc0
+  - mv nn /app/engines/lc0/
   sources:
   - type: file
     dest-filename: nn
     url: https://training.lczero.org/get_network?sha=195b450999e874d07aea2c09fd0db5eff9d4441ec1ad5a60a140fe8ea94c4f3a
-    sha256: 5cf80e9e5091134241235400366c6c46c8b1613b07b98243f4e4dcc691bf47ae
+    sha256: ece2b5e06dc7c2121c31649be0effdd645f3df53bcf801623246d75494a866ad
 
 - name: tcl # latest stable tcl, required for scid
   sources:


### PR DESCRIPTION
Closes #96 

This PR adds a flatpak manifest to create a flatpak for scid. The engines Stockfish and Lc0 (Leela chess) are bundled as well. When running the flatpak they are found in the folder `/app/bin/Engines/stockfish` and `/app/bin/Engines/lc0`, respectively.

Here is how to build the flatpak (c.f. https://docs.flatpak.org/en/latest/first-build.html):

First install flatpak and add the flathub repo as described in  https://flatpak.org/setup/ (if you do not use flatpaks yet) and then install the freedesktop runtime (which contains all the build tools among other things)
```term
flatpak install flathub org.freedesktop.Platform//22.08 org.freedesktop.Sdk//22.08
```
This has to be done only once.

Then in order to build the flatpak and create a user installation of it run
```term
flatpak-builder --user --install --force-clean build-dir com.github.benini.scid.yml
```
from inside the repository root folder (containing the flatpak manifest). Here `build-dir` is the name of a temporary build folder and can be changed if wanted. This will take a while, but should run without issues.

If everything goes well, you can run the flatpak via
```term
flatpak run com.github.benini.scid
```
According to my tests, both engines run fine and using FICS works fine as well.


Some more remarks:
- I have used the latest (stable) sources for the built modules and followed the recommendations from the Lc0 developers  for choosing a neural network.
- Maybe one could add the spellcheck, ratinglist and the player photos to the flatpak. That wouldn't be difficult either.
- The manifest can also be put into a different folder, if one wants to avoid cluttering the repository folder. 
- The goal would be to publish the app on flathub (see https://github.com/flathub/flathub/wiki/App-Submission). The manifest would then be maintained on `https://github.com/flathub/com.github.benini.scid` (which doesn't exist yet) and it could be removed again from this repository (https://github.com/benini/scid). 
- Desktop integration (icon and `.desktop` file with correct names and placed in correct folders) should probably be added as well.