### PR TITLE
Fix crash on launch on macOS

### DIFF
--- a/tcl/menus.tcl
+++ b/tcl/menus.tcl
@@ -21,7 +21,7 @@ if { $macOS } {
   $m add separator
 
   # To Quit
-  proc ::tk::mac::Quit { ::file::Exit }
+  proc ::tk::mac::Quit { args } { ::file::Exit }
 
   ## To get Help
   bind all <Command-?> {helpWindow Contents}


### PR DESCRIPTION
It seems that the lack of `args` causes scid to crash on launch on macOS. 