### PR TITLE
Bugfix for resize board after a button is pressed

### DIFF
--- a/tcl/windows/browser.tcl
+++ b/tcl/windows/browser.tcl
@@ -4,10 +4,6 @@
 
 namespace eval ::gbrowser {}
 
-proc ::gbrowser::resizeBoard { n s } {
-    set w .gb$n
-    set ::gbrowser::size [::board::resize $w.bd $s]
-}
 
 proc ::gbrowser::new {base gnum {ply -1}} {
   if {! [info exists ::gbrowser::size] } { set ::gbrowser::size 65 }
@@ -61,10 +57,10 @@ proc ::gbrowser::new {base gnum {ply -1}} {
   bind $w <Right> "::gbrowser::update $n +1"
   bind $w <Up> "::gbrowser::update $n -10"
   bind $w <Down> "::gbrowser::update $n +10"
-  bind $w <minus> "::gbrowser::resizeBoard $n -1"
-  bind $w <Control-Shift-Left> "::gbrowser::resizeBoard $n -1"
-  bind $w <plus> "::gbrowser::resizeBoard $n +1"
-  bind $w <Control-Shift-Right> "::gbrowser::resizeBoard $n +1"
+  bind $w <minus> "set ::gbrowser::size \[::board::resize $w.bd -1\]"
+  bind $w <Control-Shift-Left> "set ::gbrowser::size \[::board::resize $w.bd -1\]"
+  bind $w <plus> "set ::gbrowser::size \[::board::resize $w.bd +1\]"
+  bind $w <Control-Shift-Right> "set ::gbrowser::size \[::board::resize $w.bd +1\]"
   bindMouseWheel $w "::gbrowser::mousewheelHandler $n"
 
   ttk::button $w.b.start -image tb_start -command "::gbrowser::update $n start"

--- a/tcl/windows/browser.tcl
+++ b/tcl/windows/browser.tcl
@@ -4,6 +4,11 @@
 
 namespace eval ::gbrowser {}
 
+proc ::gbrowser::resizeBoard { n s } {
+    set w .gb$n
+    set ::gbrowser::size [::board::resize $w.bd $s]
+}
+
 proc ::gbrowser::new {base gnum {ply -1}} {
   if {! [info exists ::gbrowser::size] } { set ::gbrowser::size 65 }
   options.save ::gbrowser::size
@@ -56,10 +61,10 @@ proc ::gbrowser::new {base gnum {ply -1}} {
   bind $w <Right> "::gbrowser::update $n +1"
   bind $w <Up> "::gbrowser::update $n -10"
   bind $w <Down> "::gbrowser::update $n +10"
-  bind $w <minus> {set ::gbrowser::size [::board::resize %W.bd -1]}
-  bind $w <Control-Shift-Left> {set ::gbrowser::size [::board::resize %W.bd -1]}
-  bind $w <plus> {set ::gbrowser::size [::board::resize %W.bd +1]}
-  bind $w <Control-Shift-Right> {set ::gbrowser::size [::board::resize %W.bd +1]}
+  bind $w <minus> "::gbrowser::resizeBoard $n -1"
+  bind $w <Control-Shift-Left> "::gbrowser::resizeBoard $n -1"
+  bind $w <plus> "::gbrowser::resizeBoard $n +1"
+  bind $w <Control-Shift-Right> "::gbrowser::resizeBoard $n +1"
   bindMouseWheel $w "::gbrowser::mousewheelHandler $n"
 
   ttk::button $w.b.start -image tb_start -command "::gbrowser::update $n start"


### PR DESCRIPTION
After a button was pressed the keys "-" and "+" does not work. Fixed with this change 