### PR TITLE
Disentangle board from game

### DIFF
--- a/tcl/board.tcl
+++ b/tcl/board.tcl
@@ -1606,7 +1606,8 @@ proc  ::board::lastMoveHighlight {w moveuci} {
 #
 proc ::board::update {w {boardValues "" } {animate 0}} {
   set oldboard $::board::_data($w)
-  # boardValues are all infos about the the board, no need to look elsewhere
+  # boardValues are a list of all infos about the the board, no need to look elsewhere
+  # board: board string; lastmove as uci; attacks: list of attacked squares like [sc_pos attacks] 
   lassign $boardValues board lastmove attacks
   if {$board == ""} {
     set board $::board::_data($w)

--- a/tcl/game.tcl
+++ b/tcl/game.tcl
@@ -328,7 +328,7 @@ namespace eval ::notify {
     }
 
     ::board::setmarks .main.board [sc_pos getComment]
-    ::board::update .main.board [sc_pos board] [expr {$animate ne ""}]
+    ::board::update .main.board [list [sc_pos board] [sc_game info previousMoveUCI] [sc_pos attacks]] [expr {$animate ne ""}]
 
     after cancel ::notify::privPosChanged
     update idletasks

--- a/tcl/tools/analysis.tcl
+++ b/tcl/tools/analysis.tcl
@@ -2900,7 +2900,7 @@ proc updateAnalysisBoard {n moves} {
     
     # Make the engine moves and update the board:
     sc_move_add $moves $n
-    ::board::update $bd [sc_pos board]
+    ::board::update $bd [list [sc_pos board] [string range $moves end-3 end] ""]
     if { $::analysis(score$n) ne "" } {
         ::board::updateEvalBar $bd $::analysis(score$n)
     }


### PR DESCRIPTION
This is the continuation of "Use board data to calculate material difference.  (#127)"
The object board should be independent from .main or game.
All needed data should be transferred to board on ::new or ::update or the configuration procs.