### PR TITLE
loading  theme optimized at start

### DIFF
--- a/tcl/start.tcl
+++ b/tcl/start.tcl
@@ -519,10 +519,10 @@ proc configure_style {} {
     option add [lindex $elem 1] [lindex $elem 2]
   }
 }
-bind . <<ThemeChanged>> { if {"%W" eq "."} { configure_style } }
-
 catch { ttk::style theme use $::lookTheme }
 configure_menus
+configure_style
+bind . <<ThemeChanged>> { if {"%W" eq "."} { configure_style } }
 
 
 # Uses the circle and full circle unicode characters to simulate a switch button.


### PR DESCRIPTION
At start: after loading the style first configure menu and second configure style. This avoid to override menu settings from themeOptions. Al last bind the event.