### PR TITLE
premove only executed after receiving a move from fics and show corre…

### DIFF
--- a/tcl/tools/fics.tcl
+++ b/tcl/tools/fics.tcl
@@ -706,8 +706,6 @@ namespace eval fics {
       set line [string map {"\a" ""} $line]
       readparse $line
     }
-
-    ::fics::makePremove
   }
 
   ################################################################################
@@ -1351,6 +1349,7 @@ namespace eval fics {
       }
       ::notify::GameChanged
     }
+    ::fics::makePremove
   }
   ################################################################################
   #
@@ -1676,7 +1675,7 @@ namespace eval fics {
       if { $::fics::premoveEnabled && $::fics::playing == -1 && $sq2 != -1 } {
           set ::fics::premoveSq1 $sq1
           set ::fics::premoveSq2 $sq2
-          ::board::mark::DrawArrow .main.board.bd $sq2 $sq1 $::highlightLastMoveColor
+          ::board::mark::DrawArrow .main.board.bd $sq1 $sq2 $::highlightLastMoveColor
           return 1
       }
       return 0


### PR DESCRIPTION
…ct direction of premove arrow

premove was executed every time a string receives from fics, but fics send empty string after a move. This triggered a second premove during promotion request. Now premove will only executed after a move is received from fics. The premove arrow was shown in the wrong direction
