### PR TITLE
Use piece values for 'Gloss of danger '

### DIFF
--- a/gtest/CMakeLists.txt
+++ b/gtest/CMakeLists.txt
@@ -14,7 +14,7 @@
 # along with Scid. If not, see <http://www.gnu.org/licenses/>.
 
 cmake_minimum_required(VERSION 3.2)
-set(CMAKE_CXX_STANDARD 17 CACHE STRING "")
+set(CMAKE_CXX_STANDARD 20 CACHE STRING "")
 
 # googletest
 if(NOT IS_DIRECTORY "${CMAKE_BINARY_DIR}/googletest")

--- a/gtest/test_position.cpp
+++ b/gtest/test_position.cpp
@@ -866,3 +866,62 @@ TEST(Test_PrintFen, illegal_castling_flag) {
 		}
 	}
 }
+
+struct treeCalcAttacksTestCaseT {
+  const char*   position;
+  const squareT square;
+  const int     expectedScore;
+  const bool    hasCaptures;
+};
+
+TEST(Test_TreeCalcAttacks, positions) {
+  // clang-format off
+  static const treeCalcAttacksTestCaseT cases[] = {
+    { "r2qkbnr/pppb1ppp/2n1p3/3p4/3P4/1QP3P1/PP2PPBP/RNB1K1NR w KQkq - 0 1",  D5,
+      1, true },
+    { "r2qkbnr/pppb1ppp/2n1p3/3p4/3P1B2/1QP3P1/PP2PPBP/RN2K1NR b KQkq - 1 1",  D4,
+      2, true },
+    { "rnbqk1nr/ppp1ppbp/3p2p1/4P3/3P4/8/PPP2PPP/RNBQKBNR w KQkq - 0 4", D6,
+      0, true },
+    { "rnbqk1nr/ppp1ppbp/3p2p1/4P3/3P1P2/8/PPP3PP/RNBQKBNR b KQkq - 0 4", E5,
+      2, true },
+    { "3rk1nr/pp2ppbp/1q4p1/4P3/3n4/1P2BB2/P5PP/RN1QK2R w KQk - 0 13", D4,
+      4, true },
+    { "rnb1k2r/ppp2ppp/5n2/2b2N2/2p1P3/4B3/PP3PPP/RN1qKB1R w KQkq - 0 8", D1,
+      -9, true },
+    { "rnb1k2r/ppp2ppp/5n2/2b2N2/2p1P3/4B3/PP3PPP/RN1qKB1R w KQkq - 0 8", C5,
+      0, false },
+    { "rnQqkb1r/pp2pBpp/2p5/6B1/3P4/2P2N2/P1b3PP/R3K2R b KQkq - 0 12", C8,
+      0, false },
+    { "2r1kb1r/1b3ppp/p3pP2/7n/Np1p4/4B2N/PP2QP1q/1K1R1BR1 b k - 2 20", H3,
+      6, true },
+    { "2r1kb1r/1b3ppp/p3pP2/7n/Np1p4/4B2N/PP2QP1q/1K1R1BR1 b k - 2 20", G1,
+      4, true },
+    { "2r1kb1r/1b3ppp/p3pP2/7n/Np1p4/4B2N/PP2QP1q/1K1R1BR1 b k - 2 20", F2,
+      8, true },
+    { "2r1kb1r/1b3ppp/p3pP2/7n/Np1p4/4B2N/PP2QP1q/1K1R1BR1 b k - 2 20", E3,
+      -2, true },
+    { "r3kb1r/pp1nqppp/2p1p1b1/6N1/2BP1BP1/2P2Q2/P6P/4RRK1 w kq - 4 14", E6,
+      -5, true }
+  };
+  // clang-format on
+
+  Position pos;
+  char buf[64];
+  auto it = std::begin(cases);
+  for (; it != std::end(cases); ++it) {
+    int score = 0;
+    bool result;
+    colorT toMove;
+    pieceT pieceUnderCapture;
+
+    pos.ReadFromFEN(it->position);
+    toMove = pos.GetToMove();
+    pieceUnderCapture = pos.GetPiece(it->square);
+    ASSERT_TRUE(pieceUnderCapture == EMPTY || piece_Color(pieceUnderCapture) == color_Flip(toMove));
+
+    result = pos.TreeCalcAttacks(&score, it->square);
+    EXPECT_EQ(result, it->hasCaptures);
+    EXPECT_EQ(score,  it->expectedScore);
+  }
+}

--- a/src/position.h
+++ b/src/position.h
@@ -18,6 +18,7 @@
 
 #include "common.h"
 #include "movelist.h"
+#include <climits>
 #include <stdio.h>
 #include <string>
 #include <string_view>
@@ -50,6 +51,16 @@ const genMovesT
     GEN_CAPTURES = 1,
     GEN_NON_CAPS = 2,
     GEN_ALL_MOVES = (GEN_CAPTURES | GEN_NON_CAPS);
+
+// Piece values for Position::CalcTreeAttacks()
+typedef int8_t pieceValueT;
+const pieceValueT
+    PV_PAWN = 1,
+    PV_KNIGHT = 3,
+    PV_BISHOP = 3,
+    PV_ROOK = 5,
+    PV_QUEEN = 9,
+    PV_KING = INT8_MAX;
 
 
 // SANList: list of legal move strings in SAN.
@@ -248,7 +259,7 @@ public:
     template <bool check_legal = true> bool canCastle(bool king_side) const;
 
     uint        CalcAttacks (colorT toMove, squareT kingSq, SquareList * squares) const;
-    int         TreeCalcAttacks (colorT toMove, squareT target);
+    bool        TreeCalcAttacks (int* dResult, squareT target);
     uint        CalcNumChecks () const {
                     return CalcAttacks (1-ToMove, GetKingSquare(), NULL);
                 }
@@ -322,4 +333,3 @@ private:
 //////////////////////////////////////////////////////////////////////
 //  EOF: position.h
 //////////////////////////////////////////////////////////////////////
-

--- a/src/tkscid.cpp
+++ b/src/tkscid.cpp
@@ -4677,13 +4677,13 @@ sc_pos (ClientData cd, Tcl_Interp * ti, int argc, const char ** argv)
             Position pos(*db->game->GetCurrentPos());
             for (colorT c = WHITE; c <= BLACK; c++) {
                 for (uint i = 0; i < pos.GetCount(c); i++) {
+                    int att;
                     squareT sq = pos.GetList(c)[i];
                     pos.SetToMove(color_Flip(c));
-                    int att = pos.TreeCalcAttacks(color_Flip(c), sq);
-                    if (att) {
+                    if (pos.TreeCalcAttacks(&att, sq)) {
                       appendUintElement(ti, sq);
-                      if (att > 1) Tcl_AppendElement(ti, "green");
-                      else if (att > 0) Tcl_AppendElement(ti, "yellow");
+                      if (att > 0) Tcl_AppendElement(ti, "green");
+                      else if (att == 0) Tcl_AppendElement(ti, "yellow");
                       else Tcl_AppendElement(ti, "red");
                     }
                 }


### PR DESCRIPTION
See #139

This PR modifies the 'gloss of danger' feature to use relative piece values when showing the _danger level_

Because a picture is worth thousand words, examples follow:

### Example 1

**Before** 
![Screenshot_20231027_184330](https://github.com/benini/scid/assets/3391348/31479f15-0493-41e5-b151-0c04533287e6)

**After**
![Screenshot_20231027_184450](https://github.com/benini/scid/assets/3391348/ffa4441f-bdc4-46e7-84b1-19a45e68c176)

### Example 2

**Before**
![Screenshot_20231027_184713](https://github.com/benini/scid/assets/3391348/a5281b8c-465f-4313-9c68-60a1839fe311)

**After**
![Screenshot_20231027_184812](https://github.com/benini/scid/assets/3391348/718a49de-123c-45c7-89ad-71a34f9db366)

### Example 3

**Before**
![Screenshot_20231027_185017](https://github.com/benini/scid/assets/3391348/b600de59-967a-462e-8967-82039ed9bd21)

**After**
![Screenshot_20231027_185055](https://github.com/benini/scid/assets/3391348/629f1b24-fe9d-49e1-bbfd-20f1dc745607)



I think these examples show adequately what the feature is about. In my humble opinion, this is an improvement compared to the original version.

The PR also adds tests of the new implementation.



