### PR TITLE
Bugfix pre comment when marks stripped

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1684,7 +1684,7 @@ errorT Game::WriteMoveList(TextBuffer* tb, moveT* oldCurrentMove,
         (PgnStyle & PGN_STYLE_COMMENTS)) {
         const char* comment = CurrentMove->prev->comment.c_str();
         if (*comment && (PgnStyle & PGN_STYLE_STRIP_MARKS)) {
-            strippedComment = CurrentMove->prev->comment.c_str();
+            strippedComment = comment;
             strTrimMarkCodes(strippedComment.data());
             comment = strippedComment.data();
         }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1684,7 +1684,7 @@ errorT Game::WriteMoveList(TextBuffer* tb, moveT* oldCurrentMove,
         (PgnStyle & PGN_STYLE_COMMENTS)) {
         const char* comment = CurrentMove->prev->comment.c_str();
         if (*comment && (PgnStyle & PGN_STYLE_STRIP_MARKS)) {
-            strippedComment = m->comment;
+            strippedComment = CurrentMove->prev->comment.c_str();
             strTrimMarkCodes(strippedComment.data());
             comment = strippedComment.data();
         }


### PR DESCRIPTION
Pre comment of a move was not show correct when option STRIP_MARKS was activ

see this pgn:
[White "White"]
[Black "Black"]
[Result "0-1"]

1. {Comment before move1} d4 {Comment after move1} d5 2. c4 ( {Comment before move2} 2. Nd2 $17 {Comment after move2} ) 2. ... c5
0-1