### PR TITLE
Correct announcement of move when variations selected

### DIFF
--- a/tcl/main.tcl
+++ b/tcl/main.tcl
@@ -545,6 +545,7 @@ proc showVars {} {
         } else  {
             sc_var moveInto [expr $cur - 1]
         }
+        ::utils::sound::AnnounceForward [sc_game info previous]
         ::notify::PosChanged "" -animate
     }
     bind .variations <Up> { set cur [.variations.lbVar selection]

--- a/tcl/main.tcl
+++ b/tcl/main.tcl
@@ -545,7 +545,6 @@ proc showVars {} {
         } else  {
             sc_var moveInto [expr $cur - 1]
         }
-        ::utils::sound::AnnounceForward [sc_game info previous]
         ::notify::PosChanged "" -animate
     }
     bind .variations <Up> { set cur [.variations.lbVar selection]

--- a/tcl/move.tcl
+++ b/tcl/move.tcl
@@ -143,12 +143,11 @@ proc ::move::Forward {{count 1}} {
 			showVars
 			set bArrows $::showVarArrows
 		} else {
-			if {! $bArrows} { sc_move forward }
+			if {! $bArrows} { sc_move forward ; ::utils::sound::AnnounceForward $move }
 		}
 
-		# Animate and speak this move:
+		# Animate
 		::notify::PosChanged "" -animate
-		::utils::sound::AnnounceForward $move
 	} else {
 		if {! $bArrows} { sc_move forward $count }
 		updateBoard

--- a/tcl/move.tcl
+++ b/tcl/move.tcl
@@ -135,21 +135,19 @@ proc ::move::Forward {{count 1}} {
 		return
 	}
 
-	set announceMove ""
 	set bArrows [::move::drawVarArrows]
 	set bVarPopup [expr {$::showVarPopup && ! $::autoplayMode && [sc_var count] != 0}]
 
-	if {! $bArrows && ! $bVarPopup} {
-		if {$count == 1} {
-			set announceMove [sc_game info next]
-		}
+	if {$bArrows || $bVarPopup} {
+		if {$bArrows} { ::move::showVarArrows }
+		if {$bVarPopup} { showVars }
+ 	} else {
 		sc_move forward $count
 		::notify::PosChanged "" -animate
+  		if {$count == 1} {
+			::utils::sound::AnnounceForward [sc_game info previous]
+		}
 	}
-
-	if {$bArrows} { ::move::showVarArrows }
-	if {$bVarPopup} { showVars }
-	if {$announceMove ne ""} { ::utils::sound::AnnounceForward $announceMove }
 }
 
 #Follow the main line or enter a variation

--- a/tcl/move.tcl
+++ b/tcl/move.tcl
@@ -135,24 +135,21 @@ proc ::move::Forward {{count 1}} {
 		return
 	}
 
+	set announceMove ""
 	set bArrows [::move::drawVarArrows]
+	set bVarPopup [eval {[sc_var count] != 0 && ! $::autoplayMode && $::showVarPopup}]
 
-	set move [sc_game info next]
-	if {$count == 1} {
-		if {[sc_var count] != 0 && ! $::autoplayMode && $::showVarPopup} {
-			showVars
-			set bArrows $::showVarArrows
-		} else {
-			if {! $bArrows} { sc_move forward ; ::utils::sound::AnnounceForward $move }
+	if {! $bArrows && ! bVarPopup} {
+		if {$count == 1} {
+			set announceMove [sc_game info next]
 		}
-
-		# Animate
+		sc_move forward $count
 		::notify::PosChanged "" -animate
-	} else {
-		if {! $bArrows} { sc_move forward $count }
-		updateBoard
 	}
+
 	if {$bArrows} { ::move::showVarArrows }
+	if {$bVarPopup} { showVars }		
+	if {$announceMove ne ""} { ::utils::sound::AnnounceForward $announceMove }
 }
 
 #Follow the main line or enter a variation

--- a/tcl/move.tcl
+++ b/tcl/move.tcl
@@ -137,7 +137,7 @@ proc ::move::Forward {{count 1}} {
 
 	set announceMove ""
 	set bArrows [::move::drawVarArrows]
-	set bVarPopup [expr ([sc_var count] != 0 && ! $::autoplayMode && $::showVarPopup) ? 1 : 0 ]
+	set bVarPopup [expr {$::showVarPopup && ! $::autoplayMode && [sc_var count] != 0}]
 
 	if {! $bArrows && ! $bVarPopup} {
 		if {$count == 1} {

--- a/tcl/move.tcl
+++ b/tcl/move.tcl
@@ -137,9 +137,9 @@ proc ::move::Forward {{count 1}} {
 
 	set announceMove ""
 	set bArrows [::move::drawVarArrows]
-	set bVarPopup [eval {[sc_var count] != 0 && ! $::autoplayMode && $::showVarPopup}]
+	set bVarPopup [expr ([sc_var count] != 0 && ! $::autoplayMode && $::showVarPopup) ? 1 : 0 ]
 
-	if {! $bArrows && ! bVarPopup} {
+	if {! $bArrows && ! $bVarPopup} {
 		if {$count == 1} {
 			set announceMove [sc_game info next]
 		}
@@ -148,7 +148,7 @@ proc ::move::Forward {{count 1}} {
 	}
 
 	if {$bArrows} { ::move::showVarArrows }
-	if {$bVarPopup} { showVars }		
+	if {$bVarPopup} { showVars }
 	if {$announceMove ne ""} { ::utils::sound::AnnounceForward $announceMove }
 }
 


### PR DESCRIPTION
Move was announced when the variation selection dialog popup. Now announce move after the selection with announcing the selected move.
Move was announced twice when the variation selection dialog was not used.
