### PR TITLE
GameChanged to PosChanged substitutions in engine.tcl

### DIFF
--- a/tcl/windows/engine.tcl
+++ b/tcl/windows/engine.tcl
@@ -781,5 +781,5 @@ proc ::enginewin::exportLines {w} {
         sc_move pgn $location
         incr i_line
     }
-    ::notify::GameChanged
+    ::notify::PosChanged pgnonly
 }

--- a/tcl/windows/engine.tcl
+++ b/tcl/windows/engine.tcl
@@ -764,7 +764,7 @@ proc ::enginewin::exportMoves {w index} {
     }
     ::undoFeature save
     sc_game import $line
-    ::notify::GameChanged
+    ::notify::PosChanged -pgn
     return true
 }
 


### PR DESCRIPTION
Replaces GameChanged with PosChanged in exportMoves and exportLines.  This seemed in line with the expectations for PosChanged.  I noticed the GameChanged calls were causing a new game to be signaled to the engine(s) when using the "add move" or "add variation" buttons.  "Add all variations" also caused this, even though the current position had not changed, only the pgn.

After the change the engine analysis runs more efficiently, in the same way as if you played the move "by hand" on the board.