### PR TITLE
Fixed two startup/event race conditions.

### DIFF
--- a/tcl/main.tcl
+++ b/tcl/main.tcl
@@ -1020,7 +1020,9 @@ proc leaveSquare { square } {
 proc pressSquare { square } {
     global selectedSq highcolor
 
-    if { ![::fics::playerCanMove] } { return } ;# not player's turn
+    if { [winfo exists .fics] } {
+        if { ![::fics::playerCanMove] } { return } ;# not player's turn
+    }
 
     # if training with calculations of var is on, just log the event
     if { [winfo exists .calvarWin] } {

--- a/tcl/main.tcl
+++ b/tcl/main.tcl
@@ -1020,9 +1020,7 @@ proc leaveSquare { square } {
 proc pressSquare { square } {
     global selectedSq highcolor
 
-    if { [winfo exists .fics] } {
-        if { ![::fics::playerCanMove] } { return } ;# not player's turn
-    }
+    if {[info procs ::fics::playerCanMove] ne "" && ![::fics::playerCanMove]} { return } ;# not player's turn
 
     # if training with calculations of var is on, just log the event
     if { [winfo exists .calvarWin] } {

--- a/tcl/misc.tcl
+++ b/tcl/misc.tcl
@@ -321,7 +321,8 @@ proc progressWindow { title text {button ""} {command "progressBarCancel"} } {
   set x [expr ([winfo screenwidth $w] - 400) / 2]
   set y [expr ([winfo screenheight $w] - 40) / 2]
   wm geometry $w +$x+$y
-  grab $w
+  update idletasks
+  catch { grab $w }
   wm withdraw $w
 
   progressBarSet $w.f.c 401 21


### PR DESCRIPTION
Just a couple quick fixes to some corner cases I ran across.

1) Clicking on a board square at startup could generate a call to playerCanMove before fics exists, popping up an error message.  Fixed by adding a check that .fics exists first, as is done in other places within that file.

2) Clicking/holding the title bar at startup, before the spellcheck file loads, can no longer result in a crash to terminal due to a progressWindow grab attempt before it is viewable.  There were other triggers for this same issue such as occasionally opening a menu at the right moment during startup.  Kept hitting this once every so often, prior to adding the update idletasks before the grab.

2a) Finally, added a catch to the progressWindow's grab call.  Found that there were still some scenarios at startup where the grab could still fail with "grab failed: another application has grab."  For example, on my OS (linux) seemed that highlighting something in the terminal after starting scid would trigger this issue.  Outside of startup I could not trigger this particular issue on any other grab calls.