### PR TITLE
Fixed Resources window attempting to load sound files without snack.

### DIFF
--- a/tcl/utils/sound.tcl
+++ b/tcl/utils/sound.tcl
@@ -216,6 +216,11 @@ proc ::utils::sound::GetDialogChooseFolder { widget } {
 
 proc ::utils::sound::OptionsDialogChooseFolder { newFolder } {
     set ::utils::sound::soundFolder [file nativename $newFolder]
+    if {! $::utils::sound::hasSound} {
+        tk_messageBox -title "Scid: Sound Files" -type ok -icon info -parent .resDialog \
+            -message [tr SoundsSoundDisabled]
+        return 0
+    }
     set numSoundFiles [::utils::sound::ReadFolder]
     tk_messageBox -title "Scid: Sound Files" -type ok -icon info -parent .resDialog \
         -message "Found $numSoundFiles of [llength $::utils::sound::soundFiles] sound files in $::utils::sound::soundFolder"
@@ -233,6 +238,12 @@ proc ::utils::sound::OptionsDialogOK {} {
   set isNewSoundFolder 0
   if {$soundFolder != $::utils::sound::soundFolder_temp} {
     set isNewSoundFolder 1
+  }
+
+  if {! $::utils::sound::hasSound} {
+    tk_messageBox -title "Scid: Sound Files" -type ok -icon info -parent .resDialog \
+        -message [tr SoundsSoundDisabled]
+    return 0
   }
   
   # Update the user-settable sound variables:


### PR DESCRIPTION
When selecting a sound folder in the Resources window, it would attempt to load the sounds even if it determined than snack was not available at startup.  Now, it still allows the folder selection, but if snack is not available, it will simply pop up a message that informs you that sounds are disabled instead of attempting to load them.