### PR TITLE
Fixed selected file and/or path not updating in Resources window.

### DIFF
--- a/tcl/file/spellchk.tcl
+++ b/tcl/file/spellchk.tcl
@@ -59,7 +59,7 @@ proc getSpellCheckFile { widget } {
     set fullname [tk_getOpenFile -initialdir [file dirname $spellCheckFile] -filetypes $ftype -title "Open Spellcheck file" -parent [winfo toplevel $widget]]
     if { $fullname != "" && [readSpellCheckFile $fullname] } {
         $widget delete 0 end
-        $widget insert end $fullname
+        $widget insert end "$fullname"
     }
 }
 

--- a/tcl/menus.tcl
+++ b/tcl/menus.tcl
@@ -597,7 +597,7 @@ proc getBooksDir { widget } {
   if {$dir != ""} {
       setBooksDir $dir
       $widget delete 0 end
-      $widget insert end $dir
+      $widget insert end "$dir"
   }
 }
 
@@ -612,7 +612,7 @@ proc getTacticsBasesDir { widget } {
   if {$dir != ""} {
       setTacticsBasesDir $dir
       $widget delete 0 end
-      $widget insert end $dir
+      $widget insert end "$dir"
   }
 }
 
@@ -628,7 +628,7 @@ proc getPhotoDir { widget } {
   if {$dir != ""} {
       if { [setPhotoDir $dir] } {
           $widget delete 0 end
-          $widget insert end $dir
+          $widget insert end "$dir"
       }
   }
 }
@@ -649,7 +649,7 @@ proc getThemePkgFile { widget} {
 	       -filetypes { {Theme "pkgIndex.tcl"} }]
   if { $fullname != "" && $fullname != $::ThemePackageFile && ! [readThemePkgFile $fullname] } {
       $widget delete 0 end
-      $widget insert end $fullname
+      $widget insert end "$fullname"
   }
 }
 
@@ -677,7 +677,7 @@ proc getECOFile { widget } {
   set fullname [tk_getOpenFile -parent [winfo toplevel $widget] -initialdir [file dirname $ecoFile] -filetypes $ftype -title "Load ECO file"]
   if { [readECOFile $fullname] } {
       $widget delete 0 end
-      $widget insert end $fullname
+      $widget insert end "$fullname"
   }
 }
 

--- a/tcl/utils/sound.tcl
+++ b/tcl/utils/sound.tcl
@@ -209,7 +209,7 @@ proc ::utils::sound::GetDialogChooseFolder { widget } {
     if {$newFolder != "" && $newFolder != $::utils::sound::soundFolder } {
         if { [::utils::sound::OptionsDialogChooseFolder $newFolder] } {
             $widget delete 0 end
-            $widget insert end $newFolder
+            $widget insert end "$newFolder"
         }
     }
 }


### PR DESCRIPTION
Simple fix so that the file/path names in the Resources window are updated at the time that the user makes a selection.  Previously the newly selected path would only show up after the Resources window was closed and opened again.