### PR TITLE
Mark square

### DIFF
--- a/tcl/board.tcl
+++ b/tcl/board.tcl
@@ -1241,8 +1241,9 @@ proc ::board::mark::DrawCircle {pathName square color} {
 # draw a rectangle on the square to mark
 proc ::board::mark::DrawSquare { pathName square color } {
   if {$square < 0  ||  $square > 63} { return }
-  set width [expr int($::boardSize / 30)]
   set box [GetBox $pathName $square]
+  set width [expr {[lindex $box 4] * 0.033}]
+  if {$width <= 0.0} {set width 1.0}
   $pathName create rectangle [expr [lindex $box 0] + $width] [expr [lindex $box 1] + $width] \
     [expr [lindex $box 2] - $width - 1] [expr [lindex $box 3] - $width - 1] \
       -outline $color -width [expr $width + 2] -tag [list mark square mark$square p$square]

--- a/tcl/board.tcl
+++ b/tcl/board.tcl
@@ -1220,20 +1220,15 @@ proc ::board::mark::add {win args} {
 #
 proc ::board::mark::DrawCircle {pathName square color} {
   # Some "constants":
-  set size 0.6	;# inner (enclosing) box size, 0.0 <  $size < 1.0
-  set width 0.1	;# outline around circle, 0.0 < $width < 1.0
+  set size 0.934  ;# inner (enclosing) box size, 0.0 <  $size < 1.0
+  set width 0.066 ;# outline around circle, 0.0 < $width < 1.0
 
   set box [GetBox $pathName $square $size]
   lappend pathName create oval [lrange $box 0 3] \
       -tag [list mark circle mark$square p$square]
-  if {$width > 0.5} {
-    ;# too thick, draw a disk instead
-    lappend pathName -fill $color
-  } else {
-    set width [expr {[lindex $box 4] * $width}]
-    if {$width <= 0.0} {set width 1.0}
-    lappend pathName -fill "" -outline $color -width $width
-  }
+  set width [expr {[lindex $box 4] * $width}]
+  if {$width <= 0.0} {set width 1.0}
+  lappend pathName -fill "" -outline $color -width $width
   eval $pathName
 }
 

--- a/tcl/board.tcl
+++ b/tcl/board.tcl
@@ -994,7 +994,7 @@ proc ::board::setmarks {w cmds} {
 
     # Normalize the mark type
     switch -glob $type {
-        ""     {set type [expr {[string length $arg2] ? "arrow" : "full"}]}
+        ""     {set type [expr {[string length $arg2] ? "arrow" : "square"}]}
         "mark" {set type "full"}
         ?      {set arg2 $type ; set type "text" }
     }
@@ -1235,6 +1235,17 @@ proc ::board::mark::DrawCircle {pathName square color} {
     lappend pathName -fill "" -outline $color -width $width
   }
   eval $pathName
+}
+
+# ::board::mark::DrawSquare --
+# draw a rectangle on the square to mark
+proc ::board::mark::DrawSquare { pathName square color } {
+  if {$square < 0  ||  $square > 63} { return }
+  set width [expr int($::boardSize / 30)]
+  set box [GetBox $pathName $square]
+  $pathName create rectangle [expr [lindex $box 0] + $width] [expr [lindex $box 1] + $width] \
+    [expr [lindex $box 2] - $width - 1] [expr [lindex $box 3] - $width - 1] \
+      -outline $color -width [expr $width + 2] -tag [list mark square mark$square p$square]
 }
 
 # ::board::mark::DrawDisk --

--- a/tcl/options.tcl
+++ b/tcl/options.tcl
@@ -181,7 +181,7 @@ set borderwidth 0
 
 # Square markers color and type
 set ::markColor green
-set ::markType full
+set ::markType square
 
 # boardCoords: 1-4 to show board Coordinates, 0 to hide them.
 set boardCoords 0

--- a/tcl/windows/comment.tcl
+++ b/tcl/windows/comment.tcl
@@ -201,7 +201,6 @@ proc ::windows::commenteditor::createWin { {focus_if_exists 1} } {
 		C C
 		D D
 		E E
-		F F
 		0 0
 		1 1
 		2 2

--- a/tcl/windows/comment.tcl
+++ b/tcl/windows/comment.tcl
@@ -186,6 +186,7 @@ proc ::windows::commenteditor::createWin { {focus_if_exists 1} } {
 	ttk::frame $w_.mf.markers
 	set i 0
 	foreach {marker lbl} {
+        square ☐
 		full █
 		circle ◯
 		disk ⬤

--- a/tcl/windows/comment.tcl
+++ b/tcl/windows/comment.tcl
@@ -186,7 +186,7 @@ proc ::windows::commenteditor::createWin { {focus_if_exists 1} } {
 	ttk::frame $w_.mf.markers
 	set i 0
 	foreach {marker lbl} {
-        square ☐
+		square ☐
 		full █
 		circle ◯
 		disk ⬤


### PR DESCRIPTION
A mark "square" is defined but not implemented :[ "variable Type {full|square|arrow|circle|disk|tux}"](https://sourceforge.net/p/scid/code/ci/master/tree/tcl/board.tcl#l1029)

This implements drawSquare and use it for %csl, set it for standard in comment editor. This mark shows a rectangle.
Advantage: the  mark from pgn data and a mark from colorsquare (used by gloss of danger and suggested move) can displayed together.
The size is a little bit smaller than a square to show also the rectangle from "highlight last move".
The function of the mark "full" is not touched.