### PR TITLE
This fixes a bug for recent files with wrong file extensions

### DIFF
--- a/tcl/file.tcl
+++ b/tcl/file.tcl
@@ -139,7 +139,7 @@ proc ::file::Open_ {{fName ""} } {
 
   set ext [string tolower [file extension "$fName"] ]
   set dbName $fName
-  if {$ext == ".si5"} { set dbName [file rootname "$fName"] }
+#  if {$ext == ".si5"} { set dbName [file rootname "$fName"] }
   if {[sc_base slot $dbName] != 0} {
     tk_messageBox -title "Scid: opening file" -message "The database you selected is already opened."
     return 1

--- a/tcl/file.tcl
+++ b/tcl/file.tcl
@@ -175,8 +175,6 @@ proc ::file::Open_ {{fName ""} } {
   } else {
     if {$ext == ".si5" || $ext eq ""} {
       set dbType "SCID5"
-      # do not set a filename without extension in the recent file list
-      if {$ext eq ""} { set fName "$fName.si5" }
     } elseif {$ext == ".si4"} {
       set dbType "SCID4"
     } else {

--- a/tcl/file.tcl
+++ b/tcl/file.tcl
@@ -139,7 +139,7 @@ proc ::file::Open_ {{fName ""} } {
 
   set ext [string tolower [file extension "$fName"] ]
   set dbName $fName
-#  if {$ext == ".si5"} { set dbName [file rootname "$fName"] }
+  if {$ext == ".si5"} { set dbName [file rootname "$fName"] }
   if {[sc_base slot $dbName] != 0} {
     tk_messageBox -title "Scid: opening file" -message "The database you selected is already opened."
     return 1
@@ -175,6 +175,8 @@ proc ::file::Open_ {{fName ""} } {
   } else {
     if {$ext == ".si5" || $ext eq ""} {
       set dbType "SCID5"
+      # do not set a filename without extension in the recent file list
+      if {$ext eq ""} { set fName "$fName.si5" }
     } elseif {$ext == ".si4"} {
       set dbType "SCID4"
     } else {

--- a/tcl/file/bookmark.tcl
+++ b/tcl/file/bookmark.tcl
@@ -176,7 +176,7 @@ proc ::bookmarks::Go {entry} {
   if {[string tolower [file extension "$fname"]] == ".si5"} { set dbName [file rootname "$fname"] }
   set slot [sc_base slot $dbName]
   if {$slot != 0} {
-    sc_base switch $slot
+    ::file::SwitchToBase $slot
   } elseif {[::file::Open $fname]} {
     return
   }
@@ -190,7 +190,6 @@ proc ::bookmarks::Go {entry} {
 
   set best [sc_game find $gnum $white $black $site $round $year $result]
   ::game::Load $best $ply
-  ::notify::DatabaseChanged
 }
 
 # ::bookmarks::DeleteChildren

--- a/tcl/file/bookmark.tcl
+++ b/tcl/file/bookmark.tcl
@@ -185,7 +185,7 @@ proc ::bookmarks::Go {entry} {
     }
     unbusyCursor .
     set ::glist 1
-    ::recentFiles::add "[file rootname $fname].si4"
+    ::recentFiles::add $fname
   }
   # Find and load the best database game matching the bookmark:
   set white [lindex $entry 5]

--- a/tcl/file/bookmark.tcl
+++ b/tcl/file/bookmark.tcl
@@ -172,9 +172,7 @@ proc ::bookmarks::Go {entry} {
   set fname [lindex $entry 2]
   set gnum [lindex $entry 3]
   set ply [lindex $entry 4]
-  set dbName $fname
-  if {[string tolower [file extension "$fname"]] == ".si5"} { set dbName [file rootname "$fname"] }
-  set slot [sc_base slot $dbName]
+  set slot [sc_base slot $fname]
   if {$slot != 0} {
     ::file::SwitchToBase $slot
   } elseif {[::file::Open $fname]} {

--- a/tcl/file/bookmark.tcl
+++ b/tcl/file/bookmark.tcl
@@ -172,20 +172,13 @@ proc ::bookmarks::Go {entry} {
   set fname [lindex $entry 2]
   set gnum [lindex $entry 3]
   set ply [lindex $entry 4]
-  set slot [sc_base slot $fname]
+  set dbName $fName
+  if {$ext == ".si5"} { set dbName [file rootname "$fName"] }
+  set slot [sc_base slot $dbName]
   if {$slot != 0} {
     sc_base switch $slot
-  } else {
-    busyCursor .
-    if {[catch { ::file::Open $fname} result]} {
-      unbusyCursor .
-      tk_messageBox -icon warning -type ok -parent . \
-        -title "Scid" -message "Unable to load the database:\n$fname\n\n$result"
-      return
-    }
-    unbusyCursor .
-    set ::glist 1
-    ::recentFiles::add $fname
+  } else if {! [::file::Open $fname]} {
+    return
   }
   # Find and load the best database game matching the bookmark:
   set white [lindex $entry 5]
@@ -196,14 +189,7 @@ proc ::bookmarks::Go {entry} {
   set result [lindex $entry 10]
 
   set best [sc_game find $gnum $white $black $site $round $year $result]
-  if {[catch {::game::Load $best}]} {
-    tk_messageBox -icon warning -type ok -parent . \
-      -title "Scid" -message "Unable to load game number: $best"
-  } else {
-    sc_move pgn $ply
-  }
-  ::notify::GameChanged
-  ::notify::DatabaseChanged
+  ::game::Load $best $ply
 }
 
 # ::bookmarks::DeleteChildren

--- a/tcl/file/bookmark.tcl
+++ b/tcl/file/bookmark.tcl
@@ -172,12 +172,12 @@ proc ::bookmarks::Go {entry} {
   set fname [lindex $entry 2]
   set gnum [lindex $entry 3]
   set ply [lindex $entry 4]
-  set dbName $fName
-  if {$ext == ".si5"} { set dbName [file rootname "$fName"] }
+  set dbName $fname
+  if {[string tolower [file extension "$fname"]] == ".si5"} { set dbName [file rootname "$fname"] }
   set slot [sc_base slot $dbName]
   if {$slot != 0} {
     sc_base switch $slot
-  } else if {! [::file::Open $fname]} {
+  } elseif {[::file::Open $fname]} {
     return
   }
   # Find and load the best database game matching the bookmark:
@@ -190,6 +190,7 @@ proc ::bookmarks::Go {entry} {
 
   set best [sc_game find $gnum $white $black $site $round $year $result]
   ::game::Load $best $ply
+  ::notify::DatabaseChanged
 }
 
 # ::bookmarks::DeleteChildren

--- a/tcl/file/recent.tcl
+++ b/tcl/file/recent.tcl
@@ -76,7 +76,7 @@ proc ::recentFiles::add {fname} {
 #
 proc ::recentFiles::load {fname} {
   set rname $fname
-  if {[file extension $rname] == ".si4"} {
+  if {[file extension $rname] == ".si5"} {
     set rname [file rootname $rname]
   }
   ::file::Open $fname

--- a/tcl/file/recent.tcl
+++ b/tcl/file/recent.tcl
@@ -75,10 +75,6 @@ proc ::recentFiles::add {fname} {
 #   if it is already open.
 #
 proc ::recentFiles::load {fname} {
-  set rname $fname
-  if {[file extension $rname] == ".si5"} {
-    set rname [file rootname $rname]
-  }
   ::file::Open $fname
 }
 


### PR DESCRIPTION
Bookmarks from database si5 causes double entries in recent file list like"filename" and "filename.si5". If this bookmarks are opened then this causes entries with wrong filenames like "filename.si4"

This fix has the disadvantages that the extension si5 is not hidden.
Maybe you find a better solution. I do not know when and how the si5 extension can or should be dispensed.