### PR TITLE
Score popup

### DIFF
--- a/tcl/board.tcl
+++ b/tcl/board.tcl
@@ -385,18 +385,27 @@ proc ::board::san {sqno} {
 # Show a pop-up board.
 # xc and yc are the coordinates of the top-left corner, or the bottom-left
 # corner if above is not "".
-proc ::board::popup {w positionLongStr xc yc {above ""}} {
+proc ::board::popup {w positionLongStr xc yc {above ""} {textleft "" } {textright ""}} {
     set psize 30
     if {$psize > $::boardSize} { set psize $::boardSize }
 
     if {! [winfo exists $w]} {
         toplevel $w
         wm overrideredirect $w 1
+        ::applyThemeColor_background $w
+        ttk::label $w.l
+        ttk::label $w.r
+        if { $textleft ne "" || $textright ne "" } {
+            grid $w.l -sticky w -row 0 -column 0
+            grid $w.r -sticky e -row 0 -column 1
+        }
         ::board::new $w.bd $psize
-        grid $w.bd
+        grid $w.bd -row 1 -columnspan 2
         ::update idletasks
     }
 
+    $w.l configure -text $textleft
+    $w.r configure -text $textright
     lassign $positionLongStr pos lastmove
     ::board::update $w.bd $pos
 

--- a/tcl/tools/graphs.tcl
+++ b/tcl/tools/graphs.tcl
@@ -642,7 +642,8 @@ proc ::tools::graphs::score::Refresh { {docreate 1 }} {
           -variable ::tools::graphs::score::$i -offvalue "0" -onvalue "1" \
           -command "::tools::graphs::score::Refresh"
     }
-    canvas $w.c -width 500 -height 300 -selectforeground [ttk::style lookup . -foreground] -background [ttk::style lookup . -background]
+    canvas $w.c -width 500 -height 300
+    applyThemeStyle . $w.c
 
     $w.c create text 25 5 -tag text -justify center -width 1 \
         -font font_Regular -anchor n
@@ -700,8 +701,8 @@ proc ::tools::graphs::score::Refresh { {docreate 1 }} {
   }
 
   ::utils::graph::create score -width $width -height $height -xtop 25 -ytop 25 \
-      -ytick $yticks -xtick 5 -font font_Small -canvas $w.c -textcolor black \
-      -hline [list [list gray80 1 each $yticks ]] \
+      -ytick $yticks -xtick 5 -font font_Small -canvas $w.c -textcolor [ttk::style lookup $w.c -foreground]\
+      -hline [list [list gray80 1 each $yticks ]] -background [ttk::style lookup $w.c -background]\
       -vline {{gray80 1 each 1} {steelBlue 1 each 5}}
 
   # Create fake dataset with bounds so we see at least -1.0 to 1.0:

--- a/tcl/tools/graphs.tcl
+++ b/tcl/tools/graphs.tcl
@@ -612,8 +612,8 @@ proc ::tools::graphs::MoveScoreList { invw invb } {
 
 proc ::tools::graphs::score::Refresh { {docreate 1 }} {
   set linecolor red
-  set firstColor darkgreen
-  set secondColor blue
+  set firstColor green
+  set secondColor dodgerblue3
   set linewidth 2
   set psize 2
   

--- a/tcl/tools/graphs.tcl
+++ b/tcl/tools/graphs.tcl
@@ -585,6 +585,7 @@ proc ::tools::graphs::MoveScoreList { invw invb } {
     set gnum [sc_game number]
     set game [sc_base getGame $base $gnum live]
     set n [llength $game]
+    set ::tools::graphs::score::startFen [lindex [lindex $game 0] 2]
     set movenr 0
     for {set i 0} { $i < $n} { incr i } {
         set RAVd [lindex [lindex $game $i] 0]
@@ -807,7 +808,7 @@ proc ::tools::graphs::score::Popup {w positionLongStr label xc yc {above ""}} {
 proc ::tools::graphs::score::ShowEvalDetails {mc xc yc} {
   set x [expr {round([::utils::graph::xunmap score $mc] * 2 + 0.5)} ]
   if { $x < 1 } { return }
-  set bd [sc_pos board "position startpos moves" [lrange $::tools::graphs::score::Moves 0 $x]]
+  set bd [sc_pos board "position fen $::tools::graphs::score::startFen moves" [lrange $::tools::graphs::score::Moves 0 $x]]
   set label "[expr int(($x+1) / 2)]. "
   if { ! [expr $x % 2] } {  append label "... " }
   append label "[lindex $::tools::graphs::score::Moves $x]\nEvaluation: [lindex $::tools::graphs::score::Evals $x]"

--- a/tcl/tools/graphs.tcl
+++ b/tcl/tools/graphs.tcl
@@ -669,6 +669,8 @@ proc ::tools::graphs::score::Refresh { {docreate 1 }} {
       ::utils::graph::redraw score
     }
     bind $w.c <1> {::tools::graphs::score::Move %x}
+    bind $w.c <ButtonPress-$::MB3> {::tools::graphs::score::Popup %x %X %Y}
+    bind $w.c <ButtonRelease-$::MB3> { if {[winfo exists .scorePopup]} {wm withdraw .scorePopup} }
     wm title $w "Scid: [tr ToolsScore]"
     ::createToplevelFinalize $w
     ::tools::graphs::score::ConfigMenus
@@ -756,6 +758,15 @@ proc ::tools::graphs::score::Move {xc} {
   updateBoard
 }
 
+proc ::tools::graphs::score::Popup {mc xc yc} {
+  set x [expr {round([::utils::graph::xunmap score $mc] * 2 + 0.5)} ]
+  sc_game push copyfast
+  sc_move start
+  sc_move forward $x
+  set bd [sc_pos board]
+  sc_game pop
+  ::board::popup .scorePopup $bd $xc $yc
+}
 
 ####################
 # Rating graph

--- a/tcl/tools/graphs.tcl
+++ b/tcl/tools/graphs.tcl
@@ -579,6 +579,7 @@ proc MoveTimeList {color add} {
 proc ::tools::graphs::MoveScoreList { invw invb } {
     set moveScores { }
     set mainline { }
+    set ::tools::graphs::score::Moves { }
     set base [sc_base current]
     set gnum [sc_game number]
     set game [sc_base getGame $base $gnum live]
@@ -590,6 +591,7 @@ proc ::tools::graphs::MoveScoreList { invw invb } {
         # only search in the mainline
         if { $RAVd == 0 && $RAVn == 0} {
             lappend mainline [lindex [lindex $game $i] 4]
+            lappend ::tools::graphs::score::Moves [lindex [lindex $game $i] 5]
         }
     }
     set movenr 0.0
@@ -762,11 +764,10 @@ proc ::tools::graphs::score::Move {xc} {
 
 proc ::tools::graphs::score::Popup {mc xc yc} {
   set x [expr {round([::utils::graph::xunmap score $mc] * 2 + 0.5)} ]
-  sc_game push copyfast
-  sc_move start
-  sc_move forward $x
-  set bd [sc_pos board]
-  sc_game pop
+  if { $x < 1 } { return }
+  set bd [sc_pos board "position startpos moves" [lrange $::tools::graphs::score::Moves 0 $x]]
+  set label "[expr int(($x+1) / 2)]. "
+  if { ! [expr $x % 2] } {  append label "... " }
   ::board::popup .scorePopup $bd $xc $yc
 }
 

--- a/tcl/tools/graphs.tcl
+++ b/tcl/tools/graphs.tcl
@@ -670,8 +670,8 @@ proc ::tools::graphs::score::Refresh { {docreate 1 }} {
       ::utils::graph::redraw score
     }
     bind $w.c <1> {::tools::graphs::score::Move %x}
-    bind $w.c <ButtonPress-$::MB3> {::tools::graphs::score::Popup %x %X %Y}
-    bind $w.c <ButtonRelease-$::MB3> { if {[winfo exists .scorePopup]} {wm withdraw .scorePopup} }
+    bind $w.c <Motion> {::tools::graphs::score::Popup %x %X %Y}
+    bind $w.c <Any-Leave> { if {[winfo exists .scorePopup]} {wm withdraw .scorePopup} }
     wm title $w "Scid: [tr ToolsScore]"
     ::createToplevelFinalize $w
     ::tools::graphs::score::ConfigMenus

--- a/tcl/tools/graphs.tcl
+++ b/tcl/tools/graphs.tcl
@@ -713,7 +713,8 @@ proc ::tools::graphs::score::Refresh { {docreate 1 }} {
   set blackelo [sc_game tag get BlackElo]
   if {$whiteelo == 0} {set whiteelo ""} else {set whiteelo "($whiteelo)"}
   if {$blackelo == 0} {set blackelo ""} else {set blackelo "($blackelo)"}
-  $w.c itemconfigure text -text "[sc_game info white]$whiteelo - [sc_game info black]$blackelo  [sc_game info site]  [sc_game info date]"
+  $w.c itemconfigure text -fill [ttk::style lookup $w.c -foreground] \
+      -text "[sc_game info white]$whiteelo - [sc_game info black]$blackelo  [sc_game info site]  [sc_game info date]"
   busyCursor $w
   update
 

--- a/tcl/tools/graphs.tcl
+++ b/tcl/tools/graphs.tcl
@@ -769,10 +769,13 @@ proc ::tools::graphs::score::ShowEvalDetails {mc xc yc} {
   set x [expr {round([::utils::graph::xunmap score $mc] * 2 + 0.5)} ]
   if { $x < 1 || [llength $::tools::graphs::score::Moves] < 2 } { return }
   set bd [sc_pos board "position fen $::tools::graphs::score::startFen moves" [lrange $::tools::graphs::score::Moves 0 $x]]
-  set label "[expr int(($x+1) / 2)]. "
+  set labelL "[expr int(($x+1) / 2)]. "
   if { ! [expr $x % 2] } {  append label "... " }
-  append label "[lindex $::tools::graphs::score::Moves $x]"
-  ::board::popup .scorePopup $bd $xc $yc "" "$label" "Eval.: [lindex $::tools::graphs::score::Evals $x]"
+  append labelL "[lindex $::tools::graphs::score::Moves $x]"
+  set labelR ""
+  set eval [lindex $::tools::graphs::score::Evals $x]
+  if { $eval ne "" } { set labelR "Eval.: $eval" }
+  ::board::popup .scorePopup $bd $xc $yc "" $labelL $labelR
 }
 
 ####################

--- a/tcl/tools/graphs.tcl
+++ b/tcl/tools/graphs.tcl
@@ -765,19 +765,23 @@ proc ::tools::graphs::score::Move {xc} {
   updateBoard
 }
 
-proc ::tools::graphs::score::Popup {w positionLongStr label xc yc {above ""}} {
+proc ::tools::graphs::score::Popup {w positionLongStr textleft textright xc yc {above ""}} {
     if {! [winfo exists $w]} {
         toplevel $w
+        ::applyThemeColor_background $w
         wm overrideredirect $w 1
         ttk::label $w.l
-        grid $w.l -sticky we -row 0
+        grid $w.l -sticky w -row 0 -column 0
+        ttk::label $w.r
+        grid $w.r -sticky e -row 0 -column 1
         ::board::new $w.bd 30
-        grid $w.bd -row 1
+        grid $w.bd -row 1 -columnspan 2
         ::update idletasks
     }
-    $w.l configure -text $label
+    $w.l configure -text $textleft
+    $w.r configure -text $textright
     lassign $positionLongStr pos lastmove
-    ::board::update $w.bd $pos
+    catch { ::board::update $w.bd $pos }
 
     if {$lastmove ne ""} {
       ::board::lastMoveHighlight $w.bd $lastmove
@@ -807,12 +811,12 @@ proc ::tools::graphs::score::Popup {w positionLongStr label xc yc {above ""}} {
 
 proc ::tools::graphs::score::ShowEvalDetails {mc xc yc} {
   set x [expr {round([::utils::graph::xunmap score $mc] * 2 + 0.5)} ]
-  if { $x < 1 } { return }
+  if { $x < 1 || [llength $::tools::graphs::score::Moves] < 2 } { return }
   set bd [sc_pos board "position fen $::tools::graphs::score::startFen moves" [lrange $::tools::graphs::score::Moves 0 $x]]
   set label "[expr int(($x+1) / 2)]. "
   if { ! [expr $x % 2] } {  append label "... " }
-  append label "[lindex $::tools::graphs::score::Moves $x]\nEvaluation: [lindex $::tools::graphs::score::Evals $x]"
-  ::tools::graphs::score::Popup .scorePopup $bd $label $xc $yc
+  append label "[lindex $::tools::graphs::score::Moves $x]"
+  ::tools::graphs::score::Popup .scorePopup $bd $label "Eval.: [lindex $::tools::graphs::score::Evals $x]" $xc $yc
 }
 
 ####################

--- a/tcl/tools/graphs.tcl
+++ b/tcl/tools/graphs.tcl
@@ -765,50 +765,6 @@ proc ::tools::graphs::score::Move {xc} {
   updateBoard
 }
 
-proc ::tools::graphs::score::Popup {w positionLongStr textleft textright xc yc {above ""}} {
-    if {! [winfo exists $w]} {
-        toplevel $w
-        ::applyThemeColor_background $w
-        wm overrideredirect $w 1
-        ttk::label $w.l
-        grid $w.l -sticky w -row 0 -column 0
-        ttk::label $w.r
-        grid $w.r -sticky e -row 0 -column 1
-        ::board::new $w.bd 30
-        grid $w.bd -row 1 -columnspan 2
-        ::update idletasks
-    }
-    $w.l configure -text $textleft
-    $w.r configure -text $textright
-    lassign $positionLongStr pos lastmove
-    catch { ::board::update $w.bd $pos }
-
-    if {$lastmove ne ""} {
-      ::board::lastMoveHighlight $w.bd $lastmove
-    }
-    # Make sure the popup window can fit on the screen:
-    set screenwidth [winfo screenwidth $w]
-    set screenheight [winfo screenheight $w]
-    set dx [winfo width $w]
-    set dy [winfo height $w]
-    incr xc 8
-    if {($xc+$dx) > $screenwidth} {
-        set xc [expr {$screenwidth - $dx}]
-    }
-    if {($yc+$dy) > ($screenheight -8)} {
-            set above 1
-    }
-    if {$above ne ""} {
-        set yc [expr { $yc -$dy -8 }]
-        if {$yc < 0} { set yc 0 }
-    } else {
-        incr yc 8
-    }
-    wm geometry $w "+$xc+$yc"
-    wm deiconify $w
-    raiseWin $w
-}
-
 proc ::tools::graphs::score::ShowEvalDetails {mc xc yc} {
   set x [expr {round([::utils::graph::xunmap score $mc] * 2 + 0.5)} ]
   if { $x < 1 || [llength $::tools::graphs::score::Moves] < 2 } { return }
@@ -816,7 +772,7 @@ proc ::tools::graphs::score::ShowEvalDetails {mc xc yc} {
   set label "[expr int(($x+1) / 2)]. "
   if { ! [expr $x % 2] } {  append label "... " }
   append label "[lindex $::tools::graphs::score::Moves $x]"
-  ::tools::graphs::score::Popup .scorePopup $bd $label "Eval.: [lindex $::tools::graphs::score::Evals $x]" $xc $yc
+  ::board::popup .scorePopup $bd $xc $yc "" "$label" "Eval.: [lindex $::tools::graphs::score::Evals $x]"
 }
 
 ####################


### PR DESCRIPTION
This adresses issue https://github.com/benini/scid/issues/95

Additional: 
The coordinates and text are not readable in the score graph because background is used from theme and others is set fix.
Now the canvas colors are applied from theme and used.

Later options:
Maybe the text (playernames and date) should be moved to the window title?
This solution could also applied on rating graph. 