### PR TITLE
Figurine notation in pgn window

### DIFF
--- a/tcl/options.tcl
+++ b/tcl/options.tcl
@@ -286,6 +286,7 @@ set ::pgn::boldMainLine 1
 set ::pgn::columnFormat 0
 set ::pgn::stripMarks 0
 set ::pgn::showPhoto 1
+set ::pgn::figurine 0
 set pgnColor(Var) ""
 set pgnColor(Nag) {#cf6403}
 set pgnColor(Comment) {#008b00}
@@ -637,7 +638,7 @@ proc options.write {} {
     puts $optionF ""
     foreach i {boardSize boardStyle language ::pgn::showColor \
           ::pgn::indentVars ::pgn::indentComments ::pgn::showPhoto \
-          ::pgn::shortHeader ::pgn::boldMainLine ::pgn::stripMarks \
+          ::pgn::shortHeader ::pgn::boldMainLine ::pgn::stripMarks ::pgn::figurine \
           ::pgn::symbolicNags ::pgn::moveNumberSpaces ::pgn::columnFormat \
           tree(order) optionsAutoSave ::tree::mask::recentMask \
           ecoFile suggestMoves showVarPopup showVarArrows \

--- a/tcl/windows/pgn.tcl
+++ b/tcl/windows/pgn.tcl
@@ -110,6 +110,9 @@ namespace eval pgn {
     $w.menu.opt add checkbutton -label GInfoPhotos \
         -variable ::pgn::showPhoto -command {::pgn::Refresh 1}
 
+    #ToDo: translate label
+    $w.menu.opt add checkbutton -label "Notation Figurine" \
+        -variable ::pgn::figurine -command {::pgn::Refresh 1}
     $w.menu.color add command -label PgnColorAnno \
         -command {::pgn::ChooseColor Nag annotation}
     $w.menu.color add command -label PgnColorComments \
@@ -293,7 +296,7 @@ namespace eval pgn {
       set pgnStr [sc_game pgn -symbols $::pgn::symbolicNags \
           -indentVar $::pgn::indentVars -indentCom $::pgn::indentComments \
           -space $::pgn::moveNumberSpaces -format $format -column $::pgn::columnFormat \
-          -short $::pgn::shortHeader -markCodes $::pgn::stripMarks]
+          -short $::pgn::shortHeader -markCodes $::pgn::stripMarks -unicode $::pgn::figurine]
 
       set windowTitle [format $::tr(PgnWindowTitle) [sc_game number]]
       ::setTitle .pgnWin "$windowTitle"


### PR DESCRIPTION
Implements feature request[ #116 ](https://github.com/benini/scid/issues/116)

Code for figurine/unicode is  implemented in [game.cpp](https://github.com/benini/scid/blob/github/src/game.cpp#L1786) 
only sc_game has to be called with additional parameter