### PR TITLE
Option lichess format

### DIFF
--- a/tcl/main.tcl
+++ b/tcl/main.tcl
@@ -1093,18 +1093,34 @@ proc addMarker {w x y} {
     set to [::board::san $sq]
     if {$from == "" || $to == ""} { return }
 
-    if {$from == $to } {
-        set cmd "$::markType,$to,$::markColor"
-        set cmd_erase "\[a-z\]*,$to,\[a-z\]*"
-    } else {
-        set cmd "arrow,$from,$to,$::markColor"
-        set cmd_erase "arrow,$from,$to,\[a-z\]*"
-    }
     set oldComment [sc_pos getComment]
-    regsub -all " *\\\[%draw $cmd\\\]" $oldComment "" newComment
-    if {$newComment == $oldComment} {
-        regsub -all " *\\\[%draw $cmd_erase\\\]" $oldComment "" newComment
-        append newComment " \[%draw $cmd\]"
+    if { $::lichessFormat } {
+        set col [string toupper [string index $::markColor 0 ]]
+        if {$from == $to } {
+            set cmd "%csl $col$to"
+            set cmd_erase "%csl \[BGRYOC\]$to*"
+        } else {
+            set cmd "%cal $col$from$to"
+            set cmd_erase "%cal \[BGRYOC\]$from$to"
+        }
+        regsub -all " *\\\[$cmd\\\]" $oldComment "" newComment
+        if {$newComment == $oldComment} {
+            regsub -all " *\\\[$cmd_erase\\\]" $oldComment "" newComment
+            append newComment " \[$cmd\]"
+        }
+    } else {
+        if {$from == $to } {
+            set cmd "$::markType,$to,$::markColor"
+            set cmd_erase "\[a-z\]*,$to,\[a-z\]*"
+        } else {
+            set cmd "arrow,$from,$to,$::markColor"
+            set cmd_erase "arrow,$from,$to,\[a-z\]*"
+        }
+        regsub -all " *\\\[%draw $cmd\\\]" $oldComment "" newComment
+        if {$newComment == $oldComment} {
+            regsub -all " *\\\[%draw $cmd_erase\\\]" $oldComment "" newComment
+            append newComment " \[%draw $cmd\]"
+        }
     }
 
     sc_pos setComment $newComment
@@ -1177,7 +1193,7 @@ proc selectMarker {} {
         orange
         yellow
         blue
-        darkBlue
+        cyan
         purple
         white
         black

--- a/tcl/main.tcl
+++ b/tcl/main.tcl
@@ -1148,9 +1148,10 @@ proc selectMarker {} {
     set y [expr {max(0, $y - 40)}]
     wm geometry $w_ "+$x+$y"
 
+    applyThemeColor_background $w_
     ttk::frame $w_.markers
     set i 0
-    foreach {marker lbl} {
+    set lmark {
         full █
         circle ◯
         disk ⬤
@@ -1176,7 +1177,9 @@ proc selectMarker {} {
         7 7
         8 8
         9 9
-    } {
+    }
+    if { $::lichessFormat } { set lmark { circle ◯ } }
+    foreach {marker lbl} $lmark {
         radiobutton $w_.markers.mark_$marker \
             -indicatoron "false" \
             -foreground "$::markColor" -background "light gray" -selectcolor "dark gray" \
@@ -1187,18 +1190,9 @@ proc selectMarker {} {
     }
     ttk::frame $w_.colors
     set i 0
-    foreach color {
-        green
-        red
-        orange
-        yellow
-        blue
-        cyan
-        purple
-        white
-        black
-        gray
-    } {
+    set markColors { green red orange yellow blue cyan }
+    if { ! $::lichessFormat } { append markColors { purple white black gray } }
+    foreach color $markColors {
         radiobutton $w_.colors.col_$color \
             -indicatoron "false" \
             -background "$color" -selectcolor "$color" \

--- a/tcl/options.tcl
+++ b/tcl/options.tcl
@@ -174,6 +174,7 @@ set borderwidth 0
 # Square markers color and type
 set ::markColor green
 set ::markType full
+set ::lichessFormat 0
 
 # boardCoords: 1-4 to show board Coordinates, 0 to hide them.
 set boardCoords 0
@@ -638,7 +639,7 @@ proc options.write {} {
           moveEntry(AutoExpand) moveEntry(Coord) \
           translatePieces arrowLastMove highlightLastMove highlightLastMoveWidth \
           highlightLastMoveColor highlightLastMoveNag \
-          glossOfDanger locale(numeric) \
+          glossOfDanger ::lichessFormat locale(numeric) \
           spellCheckFile autoRaise windowsDock showGameInfo \
           exportFlags(comments) exportFlags(vars) \
           exportFlags(indentc) exportFlags(indentv) \

--- a/tcl/windows/preferences.tcl
+++ b/tcl/windows/preferences.tcl
@@ -176,6 +176,7 @@ proc ::preferences::moves { t } {
     ttk::checkbutton $t.osp -variable ::pgn::moveNumberSpaces -text [tr OptionsMovesSpace]
     ttk::checkbutton $t.sva -variable showVarArrows -text [tr OptionsMovesShowVarArrows]
     ttk::checkbutton $t.god -variable glossOfDanger -text [tr OptionsMovesGlossOfDanger] -command updateBoard
+    ttk::checkbutton $t.lic -variable ::lichessFormat -text [tr LichessFormatforCircleArrow]
 
     ttk::frame $t.auto
     ttk::label $t.auto.label -text "[tr OptionsMovesDelay]\n$::tr(AnnotateTime:)"
@@ -196,7 +197,7 @@ proc ::preferences::moves { t } {
     grid $t.high.arrow -row 1 -column 0 -columnspan 2 -sticky w
     grid $t.high.nag -row 2 -column 0 -sticky w
     pack $t.auto.label $t.auto.spDelay -side left -padx "0 10" -anchor w
-    pack $t.ani $t.omc $t.omk $t.oms $t.osv $t.osp $t.auto $t.sva $t.god -side top -anchor w
+    pack $t.ani $t.omc $t.omk $t.oms $t.osv $t.osp $t.auto $t.sva $t.god $t.lic -side top -anchor w
     pack $t.high -side top -anchor w -pady "5 0"
 }
 


### PR DESCRIPTION
Add option to store arrow and square comments in lichess format

%csl Cd3 or %Cd3d4
Option is set in preference dialog for moves
Request from [Bugreport 259](https://sourceforge.net/p/scid/bugs/259/) and [Feature Request 129](https://sourceforge.net/p/scid/feature-requests/129/)