### PR TITLE
Make header search save button work

### DIFF
--- a/tcl/search/board.tcl
+++ b/tcl/search/board.tcl
@@ -168,19 +168,8 @@ proc ::search::save_ {options_cmd} {
 		set procList [info procs $candidate]
 		set cmdList  [info commands $candidate]
 		set diagMsg "Failed invoking save candidate:\n$candidate\n\nError:\n$errMsg\n\nprocs found: [llength $procList]\ncommands found: [llength $cmdList]"
-		# Also append diagnostics to a temp file for easier copy/paste from the user.
-		set logFile "/tmp/scid_save_debug.txt"
-		set now [clock format [clock seconds] -format "%Y-%m-%d %H:%M:%S"]
-		if {[catch {set fh [open $logFile a]} openErr]} {
-			# If logging fails, still show a message box with diagnostics
-			tk_messageBox -type ok -icon error -title [::tr Save] -message $diagMsg
-		} else {
-			puts $fh "--- $now ---"
-			puts $fh $diagMsg
-			puts $fh "\n" 
-			close $fh
-			tk_messageBox -type ok -icon error -title [::tr Save] -message "Save failed; diagnostics written to: $logFile"
-		}
+		# Show diagnostics in a message box (avoid writing temp debug files).
+		tk_messageBox -type ok -icon error -title [::tr Save] -message $diagMsg
 	}
 }
 

--- a/tcl/search/board.tcl
+++ b/tcl/search/board.tcl
@@ -46,15 +46,33 @@ proc ::search::Open {ref_base ref_filter title create_subwnd} {
 	grid $w.filterOp.and $w.filterOp.or $w.filterOp.reset -ipadx 8
 
 	grid [ttk::frame $w.buttons] -sticky news
-	ttk::button $w.buttons.save -text [::tr Save] -state disabled \
+	ttk::button $w.buttons.save -text [::tr Save] -state normal \
 		-command "::search::save_ $options_cmd"
+	# Enable save button if the specific search module provides a save proc.
+	# options_cmd is the command returned by the create_subwnd (eg "::search::headerGetOptions"
+	# or "::search::boardOptions"). Try to derive the base module name and check for
+	# a corresponding "::save" procedure (e.g. "::search::header::save").
+	set save_cmd ""
+	# Remove trailing GetOptions or Options to compute the module base name.
+	if {[regsub {GetOptions$|Options$} $options_cmd "" base] > 0} {
+		set candidate "${base}::save"
+		if {[llength [info procs $candidate]] > 0 || [llength [info commands $candidate]] > 0} {
+			set save_cmd $candidate
+		}
+	}
+	if {$save_cmd ne ""} {
+		# enable and bind directly to the module's save proc
+		$w.buttons.save configure -state normal -command $save_cmd
+	}
 	ttk::button $w.buttons.reset_values -text [::tr Defaults] \
 		-command "set ::search::filterOp_($w) reset; $options_cmd reset"
+	ttk::button $w.buttons.load -text [::tr Load] -command "::search::load_ $options_cmd"
+	ttk::button $w.buttons.make_default -text [::tr "Make Default"] -command "::search::makeDefault_ $options_cmd"
 	ttk::button $w.buttons.search_new -text "[tr Search] ([tr GlistNewSort] [tr Filter])" \
 		-command "::search::start_ 1 $w $options_cmd"
 	ttk::button $w.buttons.search -text [::tr Search] \
 		-command "::search::start_ 0 $w $options_cmd"
-	grid $w.buttons.save $w.buttons.reset_values x $w.buttons.search_new $w.buttons.search -sticky w -padx "0 5"
+	grid $w.buttons.save $w.buttons.load $w.buttons.make_default $w.buttons.reset_values x $w.buttons.search_new $w.buttons.search -sticky w -padx "0 5"
 	grid columnconfigure $w.buttons 2 -weight 1
 
 	ttk::button $w.buttons.stop -text [::tr Stop] -command progressBarCancel
@@ -128,7 +146,130 @@ proc ::search::progressbar_ {w show_hide} {
 }
 
 proc ::search::save_ {options_cmd} {
-	# TODO:
+	# options_cmd is the command returned by the create_subwnd (eg
+	# "::search::headerGetOptions" or "::search::boardOptions").
+	# Derive the base module name and call its ::save proc if present.
+	if {[string length $options_cmd] == 0} {
+		tk_messageBox -type ok -icon info -title [::tr Save] -message [::tr "Save not available for this dialog"]
+		return
+	}
+
+	# Try to extract a base name: strip trailing GetOptions or Options
+	if {[regexp {^(.+)(GetOptions|Options)$} $options_cmd -> base _]} {
+		set candidate "${base}::save"
+	} else {
+		# Fallback: try to replace trailing Get... patterns conservatively
+		set candidate "${options_cmd}::save"
+	}
+
+	# Try to invoke the computed candidate directly. If it fails, inform the user.
+	if {[catch $candidate errMsg]} {
+		# Diagnostic information to help understand why the module save failed.
+		set procList [info procs $candidate]
+		set cmdList  [info commands $candidate]
+		set diagMsg "Failed invoking save candidate:\n$candidate\n\nError:\n$errMsg\n\nprocs found: [llength $procList]\ncommands found: [llength $cmdList]"
+		# Also append diagnostics to a temp file for easier copy/paste from the user.
+		set logFile "/tmp/scid_save_debug.txt"
+		set now [clock format [clock seconds] -format "%Y-%m-%d %H:%M:%S"]
+		if {[catch {set fh [open $logFile a]} openErr]} {
+			# If logging fails, still show a message box with diagnostics
+			tk_messageBox -type ok -icon error -title [::tr Save] -message $diagMsg
+		} else {
+			puts $fh "--- $now ---"
+			puts $fh $diagMsg
+			puts $fh "\n" 
+			close $fh
+			tk_messageBox -type ok -icon error -title [::tr Save] -message "Save failed; diagnostics written to: $logFile"
+		}
+	}
+}
+
+proc ::search::load_ {options_cmd} {
+	# Open a saved SearchOptions (.sso) file and source it to restore variables.
+	set ftype { { "Scid SearchOptions files" {".sso"} } }
+	set fName [tk_getOpenFile -initialdir [pwd] -filetypes $ftype -title "Open a SearchOptions file"]
+	if {$fName == ""} { return }
+	# Source the file in the global namespace so it sets variables like ::sWhite
+	set nativeName [file nativename $fName]
+	if {[catch {namespace eval :: [list source $nativeName]} errMsg]} {
+		tk_messageBox -title "Error: Unable to load file" -type ok -icon error \
+			-message "Unable to load SearchOptions file: $fName\n\nError:\n$errMsg"
+		return
+	}
+	# Update combobox history so loaded values appear and are selected
+	catch { ::utils::history::AddEntry HeaderSearchSite $::sSite }
+	catch { ::utils::history::AddEntry HeaderSearchEvent $::sEvent }
+	catch { ::utils::history::AddEntry HeaderSearchWhite $::sWhite }
+	catch { ::utils::history::AddEntry HeaderSearchBlack $::sBlack }
+	# After sourcing, the variables bound to widgets should update automatically.
+	# Refresh any open search windows so UI reflects the loaded values.
+	foreach w [array names ::search::dbase_] {
+		catch { ::search::refresh_ $w }
+		# If the window is a HeaderSearch, also re-run the create frame function
+		# to ensure widgets reflect the newly loaded variables when necessary.
+		if {[string match *.wnd_HeaderSearch $w] || [string match .wnd_HeaderSearch $w]} {
+			if {[winfo exists $w]} {
+				# try to re-evaluate header create frame to sync widgets
+				catch { ::search::headerCreateFrame $w.options }
+			}
+		}
+	}
+	tk_messageBox -type ok -icon info -title "Search Options loaded" -message "Loaded: $fName"
+}
+
+proc ::search::makeDefault_ {options_cmd} {
+	# Register current header search variables to be saved as options across restarts.
+	# List of vars and arrays to persist:
+	set vars {
+		sWhite sBlack sEvent sSite sRound sAnnotated sDateMin sDateMax
+		sResWin sResLoss sResDraw sResOther
+		sWhiteEloMin sWhiteEloMax sBlackEloMin sBlackEloMax
+		sEcoMin sEcoMax sEloDiffMin sEloDiffMax
+		sIgnoreCol sSideToMoveW sSideToMoveB sGlMin sGlMax
+		sTagName sTagValue ::search::filter::operation
+		sPgntext sHeaderFlags sTitles
+	}
+
+	foreach v $vars {
+		# Use fully-qualified options.store so we always register in global scope
+		catch { ::options.store $v }
+	}
+
+	# Now write options file to persist the registered variables
+	if {[catch { ::options.write } errMsg]} {
+		tk_messageBox -type ok -icon error -title [::tr "Make Default"] -message "Unable to save defaults:\n$errMsg"
+		return
+	}
+
+		# Previously we appended an explicit `set ::sSite [list $::sSite]` here
+		# to force persistence of the scalar site preference. That explicit
+		# append is no longer necessary because header prefs are registered
+		# via ::options.store above and written by ::options.write. Removing
+		# the manual append avoids duplicate/boilerplate entries in the
+		# options file.
+
+		# (debugging removed)
+
+	# Try to apply them immediately by sourcing the options file.
+	if {[catch { namespace eval :: [list source [scidConfigFile options]] } srcErr]} {
+		# Not fatal; inform user that restart is required to apply.
+		tk_messageBox -type ok -icon info -title [::tr "Make Default"] -message "Header search settings saved as defaults. Restart Scid to apply them on startup.\n\nSourcing options now failed: $srcErr"
+		return
+	}
+
+		# After applying defaults, update history lists so comboboxes show the
+		# new default as the selected/top entry.
+		catch { ::utils::history::AddEntry HeaderSearchSite $::sSite }
+		catch { ::utils::history::AddEntry HeaderSearchEvent $::sEvent }
+		catch { ::utils::history::AddEntry HeaderSearchWhite $::sWhite }
+		catch { ::utils::history::AddEntry HeaderSearchBlack $::sBlack }
+
+		# Refresh open search windows to reflect applied defaults
+	foreach w [array names ::search::dbase_] {
+		catch { ::search::refresh_ $w }
+	}
+
+	tk_messageBox -type ok -icon info -title [::tr "Make Default"] -message "Header search settings saved as defaults and applied to current session."
 }
 
 proc ::search::start_ {new_filter w options_cmd} {

--- a/tcl/search/header.tcl
+++ b/tcl/search/header.tcl
@@ -41,27 +41,50 @@ proc checkDates {} {
 }
 
 proc ::search::header::defaults {} {
-  set ::sWhite "";  set ::sBlack ""
-  set ::sEvent ""; set ::sSite "";  set ::sRound ""; set ::sAnnotated 0
-  set ::sTagName "Annotator";
-  set ::sTagValue "";
-  set ::sWhiteEloMin ""; set ::sWhiteEloMax ""
-  set ::sBlackEloMin ""; set ::sBlackEloMax ""
-  set ::sEloDiffMin ""; set ::sEloDiffMax ""
-  set ::sGlMin ""; set ::sGlMax ""
-  set ::sEcoMin "";  set ::sEcoMax ""; set ::sEco Yes
-  set ::sGnumMin ""; set ::sGnumMax ""
-  set ::sDateMin ""; set ::sDateMax ""
-  set ::sEventDateMin ""; set ::sEventDateMax ""
-  set ::sResWin ""; set ::sResLoss ""; set ::sResDraw ""; set ::sResOther ""
-  set ::sIgnoreCol No
-  set ::sSideToMoveW "w"
-  set ::sSideToMoveB "b"
-  foreach flag  [ concat $::sHeaderFlagList $::sHeaderCustomFlagList ] { set ::sHeaderFlags($flag) both }
-  foreach i [array names ::sPgntext] { set ::sPgntext($i) "" }
+  # Use ::options.store so existing values loaded from the options file
+  # are not overwritten. This registers default values for persistence
+  # without clobbering loaded settings on startup.
+  ::options.store ::sWhite ""
+  ::options.store ::sBlack ""
+  ::options.store ::sEvent ""
+  ::options.store ::sSite ""
+  ::options.store ::sRound ""
+  ::options.store ::sAnnotated 0
+  ::options.store ::sTagName "Annotator"
+  ::options.store ::sTagValue ""
+  ::options.store ::sWhiteEloMin ""
+  ::options.store ::sWhiteEloMax ""
+  ::options.store ::sBlackEloMin ""
+  ::options.store ::sBlackEloMax ""
+  ::options.store ::sEloDiffMin ""
+  ::options.store ::sEloDiffMax ""
+  ::options.store ::sGlMin ""
+  ::options.store ::sGlMax ""
+  ::options.store ::sEcoMin ""
+  ::options.store ::sEcoMax ""
+  ::options.store ::sEco Yes
+  ::options.store ::sGnumMin ""
+  ::options.store ::sGnumMax ""
+  ::options.store ::sDateMin ""
+  ::options.store ::sDateMax ""
+  ::options.store ::sEventDateMin ""
+  ::options.store ::sEventDateMax ""
+  ::options.store ::sResWin ""
+  ::options.store ::sResLoss ""
+  ::options.store ::sResDraw ""
+  ::options.store ::sResOther ""
+  ::options.store ::sIgnoreCol No
+  ::options.store ::sSideToMoveW "w"
+  ::options.store ::sSideToMoveB "b"
+  foreach flag [concat $::sHeaderFlagList $::sHeaderCustomFlagList] {
+    ::options.store ::sHeaderFlags($flag) both
+  }
+  foreach i [array names ::sPgntext] {
+    ::options.store ::sPgntext($i) ""
+  }
   foreach i $::sTitleList {
-    set ::sTitles(w:$i) 1
-    set ::sTitles(b:$i) 1
+    ::options.store ::sTitles(w:$i) 1
+    ::options.store ::sTitles(b:$i) 1
   }
 }
 
@@ -112,6 +135,12 @@ proc search::headerCreateFrame { w } {
   }
 
   set regular font_Small
+  # Ensure local-visible variables are populated from globals so combobox
+  # textvariables bind to the expected values when widgets are created.
+  if {[info exists ::sSite]} { set sSite $::sSite }
+  if {[info exists ::sEvent]} { set sEvent $::sEvent }
+  if {[info exists ::sWhite]} { set sWhite $::sWhite }
+  if {[info exists ::sBlack]} { set sBlack $::sBlack }
   ttk::labelframe $w.player -text $::tr(Player)
   pack $w.player -side top -fill x -pady 5
   foreach color {White Black} {
@@ -163,6 +192,83 @@ proc search::headerCreateFrame { w } {
     ttk::label $f.l$i -textvar ::tr(${i}:)
     ttk::combobox $f.e$i -textvariable s$i -width 30
     ::utils::history::SetCombobox HeaderSearch$i $f.e$i
+  }
+  # Ensure Site combobox shows saved preference immediately when present.
+  catch { ::utils::history::AddEntry HeaderSearchSite $::sSite }
+  # If ::sSite is not set in the running session, try to read the saved
+  # value from the options file and pre-populate the combobox with it.
+  if {![info exists ::sSite] || [string length $::sSite] == 0} {
+    if {[catch {set optFile [scidConfigFile options]} _] == 0 && [file exists $optFile]} {
+      if {[catch {set fh [open $optFile r]; set optContents [read $fh]; close $fh} _] == 0} {
+        # Try to find a saved sSite value. Handle both "set ::sSite iccf" and
+        # "set ::sSite [list iccf]" forms.
+        set savedSite ""
+        if {[regexp {set\s+(?:::{0,2})sSite\s+\[list\s+([^\]]+)\]} $optContents -> savedSiteMatch]} {
+          set savedSite $savedSiteMatch
+        } elseif {[regexp {set\s+(?:::{0,2})sSite\s+([^\n\r]+)} $optContents -> savedSiteMatch2]} {
+          set savedSite [string trim $savedSiteMatch2]
+        }
+        if {$savedSite ne ""} {
+          # remove surrounding quotes if any
+          if {[string match {"*"} $savedSite]} {
+            set savedSite [string range $savedSite 1 end-1]
+          }
+          # ignore empty list literal like {}
+          if {[regexp {^\{\s*\}$} $savedSite]} { set savedSite "" }
+          # If the widget already contains the value, select it; otherwise
+          # add it to the top of the values list and select it.
+          if {[catch {set vals [$f.eSite cget -values]} _] == 0} {
+            if {[string first $savedSite $vals] >= 0} {
+              # find index
+              set idx [lsearch -exact $vals $savedSite]
+              if {$idx >= 0} { catch { $f.eSite current $idx } }
+            } else {
+              # prepend and select
+              set newvals [linsert $vals 0 $savedSite]
+              catch { $f.eSite configure -values $newvals }
+              catch { $f.eSite current 0 }
+            }
+          }
+        }
+      }
+    }
+  } else {
+    # Session variable exists; ensure widget shows it
+    catch { set sSite $::sSite }
+  }
+
+  # Also handle Event similarly: populate from session or options file
+  catch { ::utils::history::AddEntry HeaderSearchEvent $::sEvent }
+  if {![info exists ::sEvent] || [string length $::sEvent] == 0} {
+    if {[catch {set optFile [scidConfigFile options]} _] == 0 && [file exists $optFile]} {
+      if {[catch {set fh [open $optFile r]; set optContents [read $fh]; close $fh} _] == 0} {
+        set savedEvent ""
+        if {[regexp {set\s+(?:::{0,2})sEvent\s+\[list\s+([^\]]+)\]} $optContents -> savedEventMatch]} {
+          set savedEvent $savedEventMatch
+        } elseif {[regexp {set\s+(?:::{0,2})sEvent\s+([^\n\r]+)} $optContents -> savedEventMatch2]} {
+          set savedEvent [string trim $savedEventMatch2]
+        }
+        if {$savedEvent ne ""} {
+          if {[string match {"*"} $savedEvent]} {
+            set savedEvent [string range $savedEvent 1 end-1]
+          }
+          # ignore empty list literal like {}
+          if {[regexp {^\{\s*\}$} $savedEvent]} { set savedEvent "" }
+          if {[catch {set vals [$f.eEvent cget -values]} _] == 0} {
+            if {[string first $savedEvent $vals] >= 0} {
+              set idx [lsearch -exact $vals $savedEvent]
+              if {$idx >= 0} { catch { $f.eEvent current $idx } }
+            } else {
+              set newvals [linsert $vals 0 $savedEvent]
+              catch { $f.eEvent configure -values $newvals }
+              catch { $f.eEvent current 0 }
+            }
+          }
+        }
+      }
+    }
+  } else {
+    catch { set sEvent $::sEvent }
   }
   pack $f.lEvent $f.eEvent -side left
   pack $f.eSite -side right
@@ -572,7 +678,34 @@ proc ::search::header::save {} {
   }
   puts $searchF "\# SearchOptions File created by Scid $::scidVersion"
   puts $searchF "set searchType Header"
-  getSearchEntries
+  # Write title selections and other entries that are not covered
+  # by the generic variable dump below. `getSearchEntries` was
+  # historically a helper that writes title arrays into the
+  # search options file. Implement a minimal compatible helper
+  # here that writes `sTitles(w:...)` and `sTitles(b:...)`.
+  proc getSearchEntries {} {
+    # This proc will be called from within ::search::header::save where
+    # the file handle `searchF` is a local variable. Use `uplevel` so
+    # the `puts $searchF ...` runs in the caller frame and can access it.
+    global sTitleList sTitles
+    foreach i $sTitleList {
+      set wval $sTitles(w:$i)
+      set bval $sTitles(b:$i)
+      uplevel [list puts $searchF "set sTitles(w:$i) [list $wval]"]
+      uplevel [list puts $searchF "set sTitles(b:$i) [list $bval]"]
+    }
+    # Also write custom flag labels if present in the current DB
+    # (these are used to label CustomFlag1..6). The code that sets
+    # these labels uses sc_base extra; attempt to write them if available.
+    if {[catch {set db [sc_base current]}]} {
+      return
+    }
+    foreach {tagname tagvalue} [sc_base extra $db] {
+      if {$tagvalue ne "" && [regexp {flag([1-6])} $tagname -> i]} {
+        uplevel [list puts $searchF "set sHeaderCustomLabel$i [list $tagvalue]"]
+      }
+    }
+  }
 
   # First write the regular variables:
   foreach i {sWhite sBlack sEvent sSite sRound sAnnotated sDateMin sDateMax sResWin

--- a/tcl/utils/history.tcl
+++ b/tcl/utils/history.tcl
@@ -142,6 +142,31 @@ proc ::utils::history::RefillCombobox {key} {
   $cbWidget delete 0 end
   set entries [GetList $key]
   $cbWidget configure -values $entries
+  # If entries exist, auto-select only when a saved preference variable
+  # exists for this history key. This ensures fields like Site will show
+  # the saved preference immediately, while other fields remain blank.
+  if {[llength $entries] > 0} {
+    set prefVar ""
+    switch -- $key {
+      HeaderSearchSite { set prefVar ::sSite }
+      HeaderSearchEvent { set prefVar ::sEvent }
+      HeaderSearchWhite { set prefVar ::sWhite }
+      HeaderSearchBlack { set prefVar ::sBlack }
+      default { set prefVar "" }
+    }
+    if {$prefVar ne "" && [info exists $prefVar] && [string length [set $prefVar]] > 0} {
+      set val [set $prefVar]
+      set idx [lsearch -exact $entries $val]
+      if {$idx >= 0} {
+        catch { $cbWidget current $idx }
+      } else {
+        # Not in entries: insert at top and select it
+        set entries [linsert $entries 0 $val]
+        $cbWidget configure -values $entries
+        catch { $cbWidget current 0 }
+      }
+    }
+  }
 }
 
 


### PR DESCRIPTION
The Save button in Header Search is greyed out and non-functional.  While there is good search functionality in the search box in the PGN window, it doesn't really work for search fields like earliest date of a game etc.  So it would be nice if the Header Search could save search parameters that a user uses often so they don't have to manually input them each time.   

This PR makes the previously greyed-out Header Search Save button functional, adds a Load button, and adds a "Make Default" button and action that persists header-search defaults across restarts.

I have tested the PR on my fork in the `make-header-search-save-button-work branch` and it seems to work as intended.

**What it does:**
Wire the search dialog Save/Load/Make Default flows so module-specific save procs are invoked and .sso files can be written and loaded.
Add a Load button to open and source saved .sso files into the running session.
Add a Make Default button that registers header-search variables with the existing options system and writes them to the options file so defaults are applied at startup.

Improve combobox/history handling so Site (and Event) show saved defaults automatically.

**Files changed:**
board.tcl — search dialog Save/Load/MakeDefault wiring and button handling
header.tcl — header save/load helpers and defaults registration
history.tcl — combobox history/refill behavior

**Notes for reviewers:**
Behavior is limited to the Tcl/Tk UI layer; core C/C++ code unchanged.
The Make Default action uses the existing ::options.store / ::options.write machinery so persistent defaults follow the project's established pattern.
Ready for testing by opening the Header Search dialog, using Save to write a .sso, Load to restore it, and Make Default to set startup defaults.

**Suggested testing steps:**
Open the Header Search dialog.
Populate Site (and other fields), click Save and write a .sso.
Use Load to load that .sso and confirm the UI updates.
Click Make Default, restart Scid, and confirm Site is auto-populated at startup.

<img width="1236" height="1284" alt="Screenshot_2025-11-23_15-29-58" src="https://github.com/user-attachments/assets/6d0cd144-8e91-4b20-ae43-244dfde765b3" />
