### PR TITLE
Add Layout Button To Header Search

### DIFF
--- a/tcl/search/board.tcl
+++ b/tcl/search/board.tcl
@@ -46,15 +46,36 @@ proc ::search::Open {ref_base ref_filter title create_subwnd} {
 	grid $w.filterOp.and $w.filterOp.or $w.filterOp.reset -ipadx 8
 
 	grid [ttk::frame $w.buttons] -sticky news
-	ttk::button $w.buttons.save -text [::tr Save] -state disabled \
-		-command "::search::save_ $options_cmd"
+	
+	# Create Layouts menubutton for Header Search, or disabled Save button for others
+	if {$title eq "HeaderSearch"} {
+		ttk::menubutton $w.buttons.layouts -text "Layouts" -menu $w.buttons.layouts.m
+		menu $w.buttons.layouts.m
+		$w.buttons.layouts.m add command -label [::tr Save] -command [list ::search::header::promptSaveLayout]
+		$w.buttons.layouts.m add separator
+		# Populate saved layouts
+		if {[info exists ::searchHeader_Layouts]} {
+			foreach name $::searchHeader_Layouts {
+				set m [menu $w.buttons.layouts.m.ly[string map {" " _} $name]]
+				$m add command -label [::tr Load] -command "::search::header::layout_load {$name}"
+				$m add command -label [::tr Delete] -command "::search::header::layout_delete {$name}; ::search::header::rebuildLayoutsMenu $w"
+				$w.buttons.layouts.m add cascade -label $name -menu $m
+			}
+		}
+		set save_widget $w.buttons.layouts
+	} else {
+		ttk::button $w.buttons.save -text [::tr Save] -state disabled \
+			-command "::search::save_ $options_cmd"
+		set save_widget $w.buttons.save
+	}
+	
 	ttk::button $w.buttons.reset_values -text [::tr Defaults] \
 		-command "set ::search::filterOp_($w) reset; $options_cmd reset"
 	ttk::button $w.buttons.search_new -text "[tr Search] ([tr GlistNewSort] [tr Filter])" \
 		-command "::search::start_ 1 $w $options_cmd"
 	ttk::button $w.buttons.search -text [::tr Search] \
 		-command "::search::start_ 0 $w $options_cmd"
-	grid $w.buttons.save $w.buttons.reset_values x $w.buttons.search_new $w.buttons.search -sticky w -padx "0 5"
+	grid $save_widget $w.buttons.reset_values x $w.buttons.search_new $w.buttons.search -sticky w -padx "0 5"
 	grid columnconfigure $w.buttons 2 -weight 1
 
 	ttk::button $w.buttons.stop -text [::tr Stop] -command progressBarCancel
@@ -108,7 +129,11 @@ proc ::search::use_dbfilter_ { unused1 w {unused2 ""} } {
 
 proc ::search::progressbar_ {w show_hide} {
 	if {$show_hide eq "show"} {
-		grid remove $w.buttons.save
+		if {[winfo exists $w.buttons.save]} {
+			grid remove $w.buttons.save
+		} elseif {[winfo exists $w.buttons.layouts]} {
+			grid remove $w.buttons.layouts
+		}
 		grid remove $w.buttons.reset_values
 		grid remove $w.buttons.search_new
 		grid remove $w.buttons.search
@@ -120,7 +145,11 @@ proc ::search::progressbar_ {w show_hide} {
 		grab release $w.buttons.stop
 		grid remove $w.buttons.stop
 		grid remove $w.progressbar
-		grid $w.buttons.save
+		if {[winfo exists $w.buttons.save]} {
+			grid $w.buttons.save
+		} elseif {[winfo exists $w.buttons.layouts]} {
+			grid $w.buttons.layouts
+		}
 		grid $w.buttons.reset_values
 		grid $w.buttons.search_new
 		grid $w.buttons.search

--- a/tcl/search/header.tcl
+++ b/tcl/search/header.tcl
@@ -199,7 +199,7 @@ proc ::search::header::promptSaveLayout {} {
       ::search::header::layout_save $name
       # Find the search window and rebuild its menu
       foreach w [winfo children .] {
-        if {[string match ".searchWin*" $w] && [winfo exists $w.top.layouts]} {
+        if {[string match ".wnd_HeaderSearch*" $w] && [winfo exists $w.buttons.layouts]} {
           ::search::header::rebuildLayoutsMenu $w
         }
       }
@@ -219,9 +219,9 @@ proc ::search::header::promptSaveLayout {} {
 
 # Rebuild the Layouts menu with current saved layouts
 proc ::search::header::rebuildLayoutsMenu {w} {
-  if {![winfo exists $w.top.layouts.m]} { return }
+  if {![winfo exists $w.buttons.layouts.m]} { return }
   
-  set m $w.top.layouts.m
+  set m $w.buttons.layouts.m
   $m delete 2 end
   
   if {[info exists ::searchHeader_Layouts]} {
@@ -268,27 +268,6 @@ proc search::headerCreateFrame { w } {
   global sEloDiffMin sEloDiffMax sSideToMoveW sSideToMoveB
   global sEco sEcoMin sEcoMax sHeaderFlags sGlMin sGlMax sTitleList sTitles
   global sResWin sResLoss sResDraw sResOther sPgntext
-
-  # Create a top frame for Layout controls
-  ttk::frame $w.top
-  pack $w.top -side top -fill x -pady {0 5}
-
-  ttk::menubutton $w.top.layouts -text "Layouts" -menu $w.top.layouts.m
-  pack $w.top.layouts -side right
-
-  menu $w.top.layouts.m
-  $w.top.layouts.m add command -label [::tr Save] -command [list ::search::header::promptSaveLayout]
-  $w.top.layouts.m add separator
-
-  # Populate saved layouts
-  if {[info exists ::searchHeader_Layouts]} {
-    foreach name $::searchHeader_Layouts {
-      set m [menu $w.top.layouts.m.ly[string map {" " _} $name]]
-      $m add command -label [::tr Load] -command "::search::header::layout_load {$name}"
-      $m add command -label [::tr Delete] -command "::search::header::layout_delete {$name}; ::search::header::rebuildLayoutsMenu $w"
-      $w.top.layouts.m add cascade -label $name -menu $m
-    }
-  }
 
   foreach frame {cWhite cBlack ignore tw tb eventsite eventround date res gl ends eco} {
     ttk::frame $w.$frame

--- a/tcl/search/header.tcl
+++ b/tcl/search/header.tcl
@@ -4,6 +4,18 @@
 
 namespace eval ::search::header {}
 
+# Store custom search layouts
+# ::searchHeader_Layouts: A list of layout names
+# ::searchHeader_Data: An array mapping layout names to their serialized data
+if {![info exists ::searchHeader_Layouts]} {
+  set ::searchHeader_Layouts {}
+}
+if {![info exists ::searchHeader_Data]} {
+  array set ::searchHeader_Data {}
+}
+::options.store ::searchHeader_Layouts
+::options.store ::searchHeader_Data
+
 set sTitleList [list gm im fm none wgm wim wfm w]
 foreach i $sTitleList {
   set sTitles(w:$i) 1
@@ -73,6 +85,156 @@ trace variable sEloDiffMax w [list ::utils::validate::Integer "-[sc_info limit e
 
 ::search::header::defaults
 
+# Save the current header search values as a named layout
+proc ::search::header::layout_save {name} {
+  # List of scalar variables to save
+  set scalar_vars {
+    sWhite sBlack sEvent sSite sRound sAnnotated
+    sDateMin sDateMax sEventDateMin sEventDateMax
+    sWhiteEloMin sWhiteEloMax sBlackEloMin sBlackEloMax
+    sEloDiffMin sEloDiffMax sGlMin sGlMax
+    sGnumMin sGnumMax sEcoMin sEcoMax sEco
+    sSideToMoveW sSideToMoveB
+    sResWin sResLoss sResDraw sResOther
+    sTagName sTagValue sVariantStd sVariant960 sIgnoreCol
+  }
+  
+  # List of array variables to save
+  set array_vars {sPgntext sHeaderFlags sTitles}
+
+  set data [list]
+
+  # Save scalars
+  foreach var $scalar_vars {
+    if {[info exists ::$var]} {
+      lappend data $var [set ::$var]
+    }
+  }
+
+  # Save arrays
+  foreach arr $array_vars {
+    if {[array exists ::$arr]} {
+      lappend data $arr [array get ::$arr]
+    }
+  }
+
+  # Store in the global data array
+  set ::searchHeader_Data($name) $data
+
+  # Add to the list of layouts if not already present
+  if {![info exists ::searchHeader_Layouts] || [lsearch -exact $::searchHeader_Layouts $name] == -1} {
+    lappend ::searchHeader_Layouts $name
+  }
+}
+
+# Load a named layout and update the UI
+proc ::search::header::layout_load {name} {
+  if {![info exists ::searchHeader_Data($name)]} { return }
+
+  # Retrieve data
+  array set data $::searchHeader_Data($name)
+
+  # Restore scalars
+  foreach var {
+    sWhite sBlack sEvent sSite sRound sAnnotated
+    sDateMin sDateMax sEventDateMin sEventDateMax
+    sWhiteEloMin sWhiteEloMax sBlackEloMin sBlackEloMax
+    sEloDiffMin sEloDiffMax sGlMin sGlMax
+    sGnumMin sGnumMax sEcoMin sEcoMax sEco
+    sSideToMoveW sSideToMoveB
+    sResWin sResLoss sResDraw sResOther
+    sTagName sTagValue sVariantStd sVariant960 sIgnoreCol
+  } {
+    if {[info exists data($var)]} {
+      set ::$var $data($var)
+    }
+  }
+
+  # Restore arrays
+  foreach arr {sPgntext sHeaderFlags sTitles} {
+    if {[info exists data($arr)]} {
+      array unset ::$arr
+      array set ::$arr $data($arr)
+    }
+  }
+}
+
+# Delete a layout
+proc ::search::header::layout_delete {name} {
+  if {[info exists ::searchHeader_Data($name)]} {
+    unset ::searchHeader_Data($name)
+  }
+  if {[info exists ::searchHeader_Layouts]} {
+    set idx [lsearch -exact $::searchHeader_Layouts $name]
+    if {$idx != -1} {
+      set ::searchHeader_Layouts [lreplace $::searchHeader_Layouts $idx $idx]
+    }
+  }
+}
+
+# Prompt user for layout name and save
+proc ::search::header::promptSaveLayout {} {
+  set name ""
+  set d .searchLayoutDialog
+  if {[winfo exists $d]} { destroy $d }
+  
+  toplevel $d
+  wm title $d "Save Search Layout"
+  wm resizable $d 0 0
+  
+  ttk::frame $d.f
+  pack $d.f -fill both -expand 1 -padx 10 -pady 10
+  
+  ttk::label $d.f.label -text "Layout name:"
+  ttk::entry $d.f.entry -width 30
+  pack $d.f.label -side top -anchor w -pady {0 5}
+  pack $d.f.entry -side top -fill x
+  
+  ttk::frame $d.f.buttons
+  pack $d.f.buttons -side top -pady {10 0}
+  
+  ttk::button $d.f.buttons.ok -text OK -command {
+    set name [.searchLayoutDialog.f.entry get]
+    if {$name ne ""} {
+      ::search::header::layout_save $name
+      # Find the search window and rebuild its menu
+      foreach w [winfo children .] {
+        if {[string match ".searchWin*" $w] && [winfo exists $w.top.layouts]} {
+          ::search::header::rebuildLayoutsMenu $w
+        }
+      }
+    }
+    destroy .searchLayoutDialog
+  }
+  ttk::button $d.f.buttons.cancel -text [::tr Cancel] -command {destroy .searchLayoutDialog}
+  pack $d.f.buttons.ok $d.f.buttons.cancel -side left -padx 5
+  
+  bind $d.f.entry <Return> "$d.f.buttons.ok invoke"
+  bind $d <Escape> "$d.f.buttons.cancel invoke"
+  
+  focus $d.f.entry
+  grab $d
+  ::tk::PlaceWindow $d widget .
+}
+
+# Rebuild the Layouts menu with current saved layouts
+proc ::search::header::rebuildLayoutsMenu {w} {
+  if {![winfo exists $w.top.layouts.m]} { return }
+  
+  set m $w.top.layouts.m
+  $m delete 2 end
+  
+  if {[info exists ::searchHeader_Layouts]} {
+    foreach name $::searchHeader_Layouts {
+      set submenu [menu $m.ly[string map {" " _} $name]]
+      $submenu delete 0 end
+      $submenu add command -label [::tr Load] -command "::search::header::layout_load {$name}"
+      $submenu add command -label [::tr Delete] -command "::search::header::layout_delete {$name}; ::search::header::rebuildLayoutsMenu $w"
+      $m add cascade -label $name -menu $submenu
+    }
+  }
+}
+
 trace variable sDateMin w ::utils::validate::Date
 trace variable sDateMax w ::utils::validate::Date
 trace variable sEventDateMin w ::utils::validate::Date
@@ -106,6 +268,27 @@ proc search::headerCreateFrame { w } {
   global sEloDiffMin sEloDiffMax sSideToMoveW sSideToMoveB
   global sEco sEcoMin sEcoMax sHeaderFlags sGlMin sGlMax sTitleList sTitles
   global sResWin sResLoss sResDraw sResOther sPgntext
+
+  # Create a top frame for Layout controls
+  ttk::frame $w.top
+  pack $w.top -side top -fill x -pady {0 5}
+
+  ttk::menubutton $w.top.layouts -text "Layouts" -menu $w.top.layouts.m
+  pack $w.top.layouts -side right
+
+  menu $w.top.layouts.m
+  $w.top.layouts.m add command -label [::tr Save] -command [list ::search::header::promptSaveLayout]
+  $w.top.layouts.m add separator
+
+  # Populate saved layouts
+  if {[info exists ::searchHeader_Layouts]} {
+    foreach name $::searchHeader_Layouts {
+      set m [menu $w.top.layouts.m.ly[string map {" " _} $name]]
+      $m add command -label [::tr Load] -command "::search::header::layout_load {$name}"
+      $m add command -label [::tr Delete] -command "::search::header::layout_delete {$name}; ::search::header::rebuildLayoutsMenu $w"
+      $w.top.layouts.m add cascade -label $name -menu $m
+    }
+  }
 
   foreach frame {cWhite cBlack ignore tw tb eventsite eventround date res gl ends eco} {
     ttk::frame $w.$frame


### PR DESCRIPTION
Based on feedback from Fulvio Benini pointing out security issues with my previous pull request (https://github.com/benini/scid/pull/211) and a very helpful/detailed design proposal, I am submitting a new PR which should supersede PR 211.  This PR adds a "Layout" button in the upper right of the Header Search Dialog that allows users to save sets of search parameters and name each collection of parameters they wish to save.  On re-entering the Header Search, you can press "Layout" again and choose to "Load" or "Delete" your named set of search parameters.  Only one file is modified.
<img width="889" height="921" alt="Screenshot_20251125_075625" src="https://github.com/user-attachments/assets/6d46c5b1-9eab-4f2c-beb2-b3cd7f1f3d7d" />
