### PR TITLE
resolver was not loaded, missing parameter for safeSource

### DIFF
--- a/tcl/tools/pinfo.tcl
+++ b/tcl/tools/pinfo.tcl
@@ -500,10 +500,10 @@ proc ::pinfo::playerInfo {{player ""}} {
 }
 
 # Call in the idlink config file.
-   if {[catch {safeSource [scidConfigFile resolvers]} ]} {
+   if {[catch {safeSource [scidConfigFile resolvers] ""} ]} {
      ::splash::add "No configuration for link resolvers found. Creating default..."
      ::pinfo::setupDefaultResolvers
-      if {[catch {safeSource [scidConfigFile resolvers]} ]} {
+      if {[catch {safeSource [scidConfigFile resolvers] ""} ]} {
          ::splash::add "Oops there is something wrong with the resolvers file..."
       } else {
          ::splash::add "Default resolvers created and loaded."


### PR DESCRIPTION
safeSource needs minimum two args, but call in pinfo.tcl has only one. 