### PR TITLE
Prevent text in comment info bar from clipping when font size is increased.

### DIFF
--- a/tcl/board.tcl
+++ b/tcl/board.tcl
@@ -531,11 +531,10 @@ proc ::board::addNamesBar {w {varname}} {
 proc ::board::addInfoBar {w varname} {
   ttk::frame $w.bar
   ttk::frame $w.bar.info
-  ttk_text $w.bar.info.t -style Toolbutton
+  ttk_text $w.bar.info.t -style Toolbutton -height 2 -width 1 -wrap word
   autoscrollBars y $w.bar.info $w.bar.info.t
   $w.bar.info.t tag bind click <Any-Enter> "$w.bar.info.t configure -cursor hand2"
   $w.bar.info.t tag bind click <Any-Leave> "$w.bar.info.t configure -cursor {}"
-  grid propagate $w.bar.info 0
   ttk::button $w.bar.leavevar -image tb_BD_BackStart -style Toolbutton
   ttk::button $w.bar.back -image tb_BD_Back -style Toolbutton
   ttk::button $w.bar.forward -image tb_BD_Forward -style Toolbutton


### PR DESCRIPTION
When you increase the font size, text in the info bar gets clipped which looks quite ugly. See image below.

<img width="728" height="50" alt="comment_clipping" src="https://github.com/user-attachments/assets/8e3d44b1-32bb-4030-bc6d-0322b4ac2091" />

This commit simply increases the height and allows text reflow. See image below for comparison after the fix is added.

<img width="702" height="75" alt="fixed" src="https://github.com/user-attachments/assets/da439d62-166c-4496-b7e0-7fbe70aefc91" />