### PR TITLE
Create dialog window hints for tiling window managers

### DIFF
--- a/tcl/main.tcl
+++ b/tcl/main.tcl
@@ -1024,6 +1024,11 @@ proc addMarker {w x y} {
 proc selectMarker {} {
     set w_ .mainSelectMarker
     toplevel $w_
+    # This small picker is a transient helper window, so tiling WMs should
+    # treat it like a floating dialog instead of a normal application window.
+    catch { wm transient $w_ . }
+    catch { wm group $w_ . }
+    catch { wm attributes $w_ -type dialog }
     if {! $::macOS } {
         wm attributes $w_ -topmost 1
     } else {

--- a/tcl/utils/win.tcl
+++ b/tcl/utils/win.tcl
@@ -264,6 +264,12 @@ proc ::win::createDialog {w {y 10}} {
 	toplevel $w -padx 10 -pady $y
 	::applyThemeColor_background $w
 
+	# Give window managers enough metadata to handle Scid dialogs as dialogs.
+	# Some tiling WMs use these hints to decide whether a window should float.
+	catch { wm transient $w . }
+	catch { wm group $w . }
+	catch { wm attributes $w -type dialog }
+
 	# Set up geometry for middle of screen:
 	after idle [list tk::PlaceWindow $w widget .]
 }


### PR DESCRIPTION
This change sets dialog-related window-manager hints for Scid dialog windows.

Tiling window managers such as i3 use these hints to recognize dialogs and open them as floating windows instead of tiling them like normal application windows.